### PR TITLE
fix: Avoid updating snapshot after calling resetAssets

### DIFF
--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -62,12 +62,14 @@ async function test() {
     currentHistoryIndex = Math.max(0, currentHistoryIndex - 1)
     const assets = assetsUpdatesHistory[currentHistoryIndex]
     creator.resetAssets(assets)
+    window.assetsSnapshot = assets
   })
 
   redoBtn.addEventListener('click', () => {
     currentHistoryIndex = Math.min(assetsUpdatesHistory.length - 1, currentHistoryIndex + 1)
     const assets = assetsUpdatesHistory[currentHistoryIndex]
     creator.resetAssets(assets)
+    window.assetsSnapshot = assets
   })
 }
 

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -25,7 +25,7 @@ pub fn connect_web_gpu_programs(programs: *const WebGpuPrograms) void {
     web_gpu_programs = programs; // orelse WebGpuPrograms{};
 }
 
-var on_asset_update_cb: *const fn ([]const AssetZig) void = &on_asset_update_noop;
+var on_asset_update_cb: *const fn ([]const AssetZig) void = undefined;
 pub fn connect_on_asset_update_callback(cb: *const fn ([]const AssetZig) void) void {
     on_asset_update_cb = cb;
 }

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -345,3 +345,44 @@ pub fn destroy_state() void {
 pub fn import_icons(data: []const f32) void {
     Msdf.init_icons(data);
 }
+
+test "reset_assets does not call the real update callback" {
+    // Setup initial state
+    init_state(100, 100);
+    // Ensure state is cleaned up after the test
+    defer destroy_state();
+
+    // Define a mock callback function locally, with its own static state.
+    const MockCallback = struct {
+        // This static variable will hold the state for our mock.
+        // It's reset to false before each test run.
+        var was_called: bool = false;
+
+        fn assets_update(_: []const AssetZig) void {
+            // Modify the static variable within the struct.
+            was_called = true;
+        }
+
+        fn assets_selection(_: u32) void {}
+    };
+
+    // Connect our mock callback. This is the "real" callback for this test.
+    connect_on_asset_update_callback(MockCallback.assets_update);
+    connect_on_asset_selection_callback(MockCallback.assets_selection);
+
+    // Call the function we are testing
+    const initial_assets = [_]AssetZig{AssetZig{
+        .points = [_]Types.PointUV{
+            Types.PointUV{ .x = 0.0, .y = 0.0, .u = 0.0, .v = 0.0 },
+            Types.PointUV{ .x = 1.0, .y = 0.0, .u = 1.0, .v = 0.0 },
+            Types.PointUV{ .x = 1.0, .y = 1.0, .u = 1.0, .v = 1.0 },
+            Types.PointUV{ .x = 0.0, .y = 1.0, .u = 0.0, .v = 1.0 },
+        },
+        .texture_id = 1,
+        .id = 123,
+    }};
+    reset_assets(&initial_assets);
+
+    // for the duration of reset_assets, the update callback should NOT be called
+    try std.testing.expect(!MockCallback.was_called);
+}

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -25,10 +25,12 @@ pub fn connect_web_gpu_programs(programs: *const WebGpuPrograms) void {
     web_gpu_programs = programs; // orelse WebGpuPrograms{};
 }
 
-var on_asset_update_cb: *const fn ([]AssetZig) void = undefined;
-pub fn connect_on_asset_update_callback(cb: *const fn ([]AssetZig) void) void {
+var on_asset_update_cb: *const fn ([]const AssetZig) void = &on_asset_update_noop;
+pub fn connect_on_asset_update_callback(cb: *const fn ([]const AssetZig) void) void {
     on_asset_update_cb = cb;
 }
+
+fn on_asset_update_noop(_: []const AssetZig) void {}
 
 var on_asset_select_cb: *const fn (u32) void = undefined;
 pub fn connect_on_asset_selection_callback(cb: *const fn (u32) void) void {
@@ -310,7 +312,10 @@ pub fn picks_render() void {
     }
 }
 
-pub fn reset_assets(new_assets: []AssetZig) void {
+pub fn reset_assets(new_assets: []const AssetZig) void {
+    const real_callback_pointer = on_asset_update_cb;
+    on_asset_update_cb = &on_asset_update_noop;
+
     state.assets.clearAndFree();
 
     for (new_assets) |asset| {
@@ -321,6 +326,8 @@ pub fn reset_assets(new_assets: []AssetZig) void {
         state.active_asset_id = 0;
         on_asset_select_cb(state.active_asset_id);
     }
+
+    on_asset_update_cb = real_callback_pointer;
 }
 
 pub fn destroy_state() void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the asset snapshot accurately reflects the current state after undo and redo actions.

* **Tests**
  * Added a test to verify that asset update callbacks are not triggered during asset resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->