### PR TITLE
fix: Recompute sdf

### DIFF
--- a/src/WebGPU/programs/computeShape/getProgram.ts
+++ b/src/WebGPU/programs/computeShape/getProgram.ts
@@ -14,7 +14,7 @@ export default function getComputeShape(device: GPUDevice, buffersToDestroy: GPU
     },
   })
 
-  return function computeSDF(
+  return function computeShape(
     passEncoder: GPUComputePassEncoder,
     curvesDataView: DataView,
     distanceScaleFactor: number,
@@ -30,7 +30,7 @@ export default function getComputeShape(device: GPUDevice, buffersToDestroy: GPU
 
     const uniformBuffer = device.createBuffer({
       label: 'computeShape uniform buffer',
-      size: 4,
+      size: 4 /*scale*/ + 12 /*padding*/,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     })
     device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([distanceScaleFactor]))

--- a/src/WebGPU/programs/computeShape/getProgram.ts
+++ b/src/WebGPU/programs/computeShape/getProgram.ts
@@ -1,31 +1,40 @@
 import shaderCode from './shader.wgsl'
 
-export default function getComputeSDF(device: GPUDevice, buffersToDestroy: GPUBuffer[]) {
+export default function getComputeShape(device: GPUDevice, buffersToDestroy: GPUBuffer[]) {
   const shaderModule = device.createShaderModule({
-    label: 'compute SDF shader',
+    label: 'computeShape shader',
     code: shaderCode,
   })
 
   const pipeline = device.createComputePipeline({
-    label: 'compute SDF pipeline',
+    label: 'computeShape pipeline',
     layout: 'auto',
     compute: {
       module: shaderModule,
     },
   })
 
-  return function drawShape(
+  return function computeSDF(
     passEncoder: GPUComputePassEncoder,
     curvesDataView: DataView,
+    distanceScaleFactor: number,
     texture: GPUTexture
   ) {
     const curvesBuffer = device.createBuffer({
-      label: 'drawShape curves buffer',
+      label: 'computeShape curves buffer',
       size: curvesDataView.byteLength,
       usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
     })
     device.queue.writeBuffer(curvesBuffer, 0, curvesDataView)
     buffersToDestroy.push(curvesBuffer)
+
+    const uniformBuffer = device.createBuffer({
+      label: 'computeShape uniform buffer',
+      size: 4,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    })
+    device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([distanceScaleFactor]))
+    buffersToDestroy.push(uniformBuffer)
 
     passEncoder.setPipeline(pipeline)
 
@@ -34,6 +43,7 @@ export default function getComputeSDF(device: GPUDevice, buffersToDestroy: GPUBu
       entries: [
         { binding: 0, resource: texture.createView() },
         { binding: 1, resource: { buffer: curvesBuffer } },
+        { binding: 2, resource: { buffer: uniformBuffer } },
       ],
     })
 

--- a/src/WebGPU/programs/computeShape/shader.wgsl
+++ b/src/WebGPU/programs/computeShape/shader.wgsl
@@ -8,8 +8,13 @@ struct CubicBezier {
   p3: vec2f,
 };
 
+struct Uniforms {
+  distance_scale: f32,
+};
+
 @group(0) @binding(0) var tex: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(1) var<storage, read> curves: array<vec2f>;
+@group(0) @binding(2) var<uniform> u: Uniforms;
 
 @compute @workgroup_size(1) fn cs(
   @builtin(global_invocation_id) id : vec3u
@@ -18,7 +23,7 @@ struct CubicBezier {
   let shape_info = evaluate_shape(pos);
 
   textureStore(tex, id.xy, vec4f(
-    shape_info.signed_distance,
+    shape_info.signed_distance * u.distance_scale,
     shape_info.t,
     shape_info.angle,
     1.0

--- a/src/WebGPU/programs/initPrograms.ts
+++ b/src/WebGPU/programs/initPrograms.ts
@@ -10,7 +10,7 @@ import getPickTriangle from './pickTriangle/getProgram'
 import getDrawMSDF from './drawMSDF/getProgram'
 import getDrawShape from './drawShape/getProgram'
 import getPickShape from './pickShape/getProgram'
-import getComputeSDF from './computeSDF/getProgram'
+import getComputeShape from './computeShape/getProgram'
 
 export let drawTriangle: ReturnType<typeof getDrawTriangle>
 export let drawBezier: ReturnType<typeof getDrawBezier>
@@ -24,7 +24,7 @@ export let pickTriangle: ReturnType<typeof getPickTriangle>
 export let drawMSDF: ReturnType<typeof getDrawMSDF>
 export let drawShape: ReturnType<typeof getDrawShape>
 export let pickShape: ReturnType<typeof getPickShape>
-export let computeSDF: ReturnType<typeof getComputeSDF>
+export let computeShape: ReturnType<typeof getComputeShape>
 
 export let canvasMatrixBuffer: GPUBuffer
 export let pickCanvasMatrixBuffer: GPUBuffer
@@ -56,7 +56,7 @@ export default function initPrograms(device: GPUDevice, presentationFormat: GPUT
   drawMSDF = getDrawMSDF(device, presentationFormat, canvasMatrixBuffer)
   drawShape = getDrawShape(device, presentationFormat, canvasMatrixBuffer, buffersToDestroy)
   pickShape = getPickShape(device, pickCanvasMatrixBuffer, buffersToDestroy)
-  computeSDF = getComputeSDF(device, buffersToDestroy)
+  computeShape = getComputeShape(device, buffersToDestroy)
 
   return function cleanup() {
     buffersToDestroy.forEach((buffer) => buffer.destroy())

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,12 @@ export default async function initCreator(
   const projectWidth = canvas.clientWidth / 2
   const projectHeight = canvas.clientHeight / 2
 
-  Logic.initState(projectWidth, projectHeight, device.limits.maxTextureDimension2D)
+  Logic.initState(
+    projectWidth,
+    projectHeight,
+    device.limits.maxTextureDimension2D,
+    device.limits.maxBufferSize
+  )
   // rotation doesnt work
   const context = canvas.getContext('webgpu')
   if (!context) throw Error('WebGPU from canvas needs to be always provided')

--- a/src/logic/get_sdf_texture_size.zig
+++ b/src/logic/get_sdf_texture_size.zig
@@ -1,0 +1,29 @@
+const PointUV = @import("types.zig").PointUV;
+const TextureSize = @import("types.zig").TextureSize;
+const shared = @import("shared.zig");
+
+pub fn get_sdf_texture_size(bounds: [4]PointUV) TextureSize {
+    var width = bounds[0].distance(bounds[1]);
+    var height = bounds[0].distance(bounds[3]);
+
+    if (width > shared.texture_max_size) {
+        const ratio = shared.texture_max_size / width;
+        width = shared.texture_max_size;
+        height *= ratio;
+    }
+
+    if (height > shared.texture_max_size) {
+        const ratio = shared.texture_max_size / height;
+        height = shared.texture_max_size;
+        width *= ratio;
+    }
+
+    const sdf_texture_size = width * height * 16;
+    if (sdf_texture_size > shared.max_buffer_size) {
+        const max_pixels = shared.max_buffer_size / 16.0;
+        const ratio = @sqrt(max_pixels / (width * height));
+        width *= ratio;
+        height *= ratio;
+    }
+    return TextureSize{ .w = @intFromFloat(width), .h = @intFromFloat(height) };
+}

--- a/src/logic/get_sdf_texture_size.zig
+++ b/src/logic/get_sdf_texture_size.zig
@@ -25,5 +25,6 @@ pub fn get_sdf_texture_size(bounds: [4]PointUV) TextureSize {
         width *= ratio;
         height *= ratio;
     }
+
     return TextureSize{ .w = @intFromFloat(width), .h = @intFromFloat(height) };
 }

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -61,7 +61,12 @@ type PointerDataView = {
 }
 
 declare module '*.zig' {
-  export const initState: (width: number, height: number, max_texture_size: number) => void
+  export const initState: (
+    width: number,
+    height: number,
+    max_texture_size: number,
+    max_buffer_size: number
+  ) => void
   export const addImage: (maybe_asset_id: number, points: PointUV[], texture_id: number) => void
   export const addShape: (
     maybe_asset_id: number,
@@ -91,6 +96,7 @@ declare module '*.zig' {
       curves_data: ArrayPointerDataView,
       width: number,
       height: number,
+      distance_scale: number,
       texture_id: number
     ) => void
     draw_shape: (
@@ -109,7 +115,7 @@ declare module '*.zig' {
   export const connectCreateSdfTexture: (cb: () => number) => void
   export const connectCacheCallbacks: (
     create_cache_texture: () => number,
-    start_cache: (texture_dd: number, box: BoundingBox, width: number, height: number) => void,
+    start_cache: (texture_id: number, box: BoundingBox, width: number, height: number) => void,
     end_cache: VoidFunction
   ) => void
 

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1,20 +1,22 @@
 const std = @import("std");
-const types = @import("./types.zig");
-const images = @import("./images.zig");
+const types = @import("types.zig");
+const images = @import("images.zig");
 const Line = @import("line.zig");
 const Triangle = @import("triangle.zig");
-const TransformUI = @import("./transform_ui.zig");
+const TransformUI = @import("transform_ui.zig");
 const zigar = @import("zigar");
-const Msdf = @import("./msdf.zig");
+const Msdf = @import("msdf.zig");
 const shapes = @import("./shapes/shapes.zig");
 const squares = @import("squares.zig");
 const bounding_box = @import("shapes/bounding_box.zig");
-const shared = @import("./shared.zig");
+const shared = @import("shared.zig");
+const get_sdf_texture_size = @import("get_sdf_texture_size.zig").get_sdf_texture_size;
+const Utils = @import("utils.zig");
 
 const WebGpuPrograms = struct {
     draw_texture: *const fn (images.DrawVertex, u32) void,
     draw_triangle: *const fn ([]const Triangle.DrawInstance) void,
-    compute_shape: *const fn ([]const types.Point, f32, f32, u32) void,
+    compute_shape: *const fn ([]const types.Point, u32, u32, f32, u32) void,
     draw_shape: *const fn ([]const types.PointUV, shapes.Uniform, u32) void,
     draw_msdf: *const fn ([]const Msdf.DrawInstance, u32) void,
     pick_texture: *const fn ([]const images.PickVertex, u32) void,
@@ -113,8 +115,9 @@ var state = State{
     .last_pointer_coords = types.Point{ .x = 0.0, .y = 0.0 },
 };
 
-pub fn initState(width: f32, height: f32, texture_max_size: f32) void {
-    _ = texture_max_size; // autofix
+pub fn initState(width: f32, height: f32, texture_max_size: f32, max_buffer_size: f32) void {
+    shared.texture_max_size = texture_max_size;
+    shared.max_buffer_size = max_buffer_size;
     state.width = width;
     state.height = height;
     state.assets = std.AutoArrayHashMap(u32, Asset).init(std.heap.page_allocator);
@@ -125,24 +128,16 @@ pub fn updateRenderScale(scale: f32) !void {
     shared.render_scale = scale;
 
     var iterator = state.assets.iterator();
-
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-    _ = allocator; // autofix
-
     while (iterator.next()) |asset| {
         switch (asset.value_ptr.*) {
             .img => {},
             .shape => |*shape| {
-                _ = shape; // autofix
-                // if (shape.cache.valid) {
-                // if it's valid, then lets update, if it's invalid, then is gonna be updated anyway(with correct fresh data)
-                // if (shape.updateTextureSize()) {
-                //     std.debug.print("texture size has changed, updating shape cache\n", .{});
-                //     try shape.drawTextureCache(allocator);
-                // }
-                // }
+                const bounds = shape.getBoundsWithPadding(1 / shared.render_scale);
+                const new_size = get_sdf_texture_size(bounds);
+
+                if (new_size.w > shape.sdf_size.w or new_size.h > shape.sdf_size.h) {
+                    shape.outdated_sdf = true;
+                }
             },
         }
     }
@@ -279,7 +274,6 @@ fn updateSelectedAsset(id: u32) !void {
     try commitChanges();
 
     state.selected_asset_id = id;
-    shapes.resetState();
     on_asset_select_cb(id);
 }
 
@@ -330,14 +324,16 @@ pub fn onPointerUp() !void {
         }
     } else if (state.tool == Tool.DrawShape) {
         try checkAssetsUpdate(true);
-        shapes.onReleasePointer();
+        if (getSelectedShape()) |shape| {
+            shape.onReleasePointer();
+        }
     }
 }
 
 pub fn onPointerMove(x: f32, y: f32) !void {
     if (state.tool == Tool.DrawShape) {
         if (getSelectedShape()) |shape| {
-            try shape.updatePointPreview(x, y);
+            try shape.updatePointPreview(types.Point{ .x = x, .y = y });
         }
         return;
     }
@@ -394,7 +390,7 @@ fn updateShapeCache(shape: *shapes.Shape) !void {
 pub fn commitChanges() !void {
     if (state.tool == Tool.DrawShape) {
         if (getSelectedShape()) |shape| {
-            try updateShapeCache(shape);
+            shape.update_preview_point(null);
         }
 
         shapes.resetState();
@@ -527,14 +523,26 @@ pub fn calculateShapesSDF() !void {
         switch (asset.value_ptr.*) {
             .img => {},
             .shape => |*shape| {
-                const option_points = try shape.getDrawVertexData(allocator, shape.id == state.selected_asset_id);
-
+                if (!shape.outdated_sdf) {
+                    continue;
+                }
+                const option_points = try shape.getNewSdfPoint(allocator);
                 if (option_points) |points| {
-                    const bounds = shape.getBoundsWithPadding();
+                    const bounds = shape.getBoundsWithPadding(1 / shared.render_scale);
+                    const init_width = bounds[0].distance(bounds[1]);
+                    shape.sdf_size = get_sdf_texture_size(bounds);
+                    const scale = @as(f32, @floatFromInt(shape.sdf_size.w)) / init_width;
+
+                    for (points) |*point| {
+                        point.x *= scale;
+                        point.y *= scale;
+                    }
+
                     web_gpu_programs.compute_shape(
                         points,
-                        bounds[0].distance(bounds[1]),
-                        bounds[0].distance(bounds[3]),
+                        shape.sdf_size.w,
+                        shape.sdf_size.h,
+                        1 / scale,
                         shape.texture_id,
                     );
                 }
@@ -578,10 +586,7 @@ pub fn renderDraw() !void {
 
     if (state.tool == Tool.DrawShape) {
         if (getSelectedShape()) |shape| {
-            const vertex_data = try shape.getSkeletonDrawVertexData(
-                allocator,
-                shape.id == state.selected_asset_id,
-            );
+            const vertex_data = try shape.getSkeletonDrawVertexData(allocator);
             web_gpu_programs.draw_triangle(vertex_data);
             web_gpu_programs.draw_shape(&shape.getDrawBounds(), shapes.getSkeletonUniform(), shape.texture_id);
         }

--- a/src/logic/shapes/paths.zig
+++ b/src/logic/shapes/paths.zig
@@ -119,7 +119,7 @@ pub const Path = struct {
                 point.y - size / 2.0,
                 size,
                 size,
-                SKELETON_POINT_SIZE / 2.0,
+                size / 2.0,
                 [_]u8{ 0, 0, 255, 255 },
             );
         }

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -1,6 +1,7 @@
 const Utils = @import("../utils.zig");
 const Point = @import("../types.zig").Point;
 const PointUV = @import("../types.zig").PointUV;
+const TextureSize = @import("../types.zig").TextureSize;
 const std = @import("std");
 const bounding_box = @import("bounding_box.zig");
 const triangles = @import("../triangle.zig");
@@ -14,17 +15,13 @@ const DEFAULT_BOUNDS = @import("../consts.zig").DEFAULT_BOUNDS;
 
 const EPSILON = std.math.floatEps(f32);
 
+// this state is not included in the shape struct only because there is no need, methods which uses these variables
+// are called only when shape is selected, so only one active shape/path uses them
 var active_path_index: ?usize = null;
 var is_handle_preview: bool = false;
-var preview_point: ?Point = null;
 
 pub fn resetState() void {
     active_path_index = null;
-    is_handle_preview = false;
-    preview_point = null;
-}
-
-pub fn onReleasePointer() void {
     is_handle_preview = false;
 }
 
@@ -42,7 +39,7 @@ pub const Preview = struct {
 
 pub fn getSkeletonUniform() Uniform {
     return Uniform{
-        .stroke_width = 2.0 * shared.render_scale,
+        .stroke_width = 2.0,
         .fill_color = .{ 0.0, 0.0, 0.0, 0.0 },
         .stroke_color = .{ 0.0, 0.0, 1.0, 1.0 },
     };
@@ -64,6 +61,10 @@ pub const Shape = struct {
     bounds: [4]PointUV,
     outdated_sdf: bool, // if true, we need to recalculate SDF
     texture_id: u32,
+    preview_point: ?Point = null,
+
+    sdf_size: TextureSize = .{ .w = 0, .h = 0 }, // stores the last size of computed sdf
+    // useful only while updating scale to avoid unnecessary regenerations if size hasn't grown
 
     pub fn new(
         id: u32,
@@ -85,19 +86,14 @@ pub const Shape = struct {
             );
             try paths_list.append(path);
         }
-        var shape = Shape{
+        const shape = Shape{
             .id = id,
             .paths = paths_list,
             .props = props,
             .texture_id = texture_id,
-            .outdated_sdf = false,
+            .outdated_sdf = true,
             .bounds = bounds,
         };
-
-        const from_svg_file = input_bounds == null and input_paths.len > 0;
-        if (from_svg_file) {
-            try shape.update_bounds(allocator, null);
-        }
 
         return shape;
     }
@@ -110,12 +106,11 @@ pub const Shape = struct {
         is_handle_preview = true;
 
         if (self.paths.items.len == 0) {
-            self.bounds = [4]PointUV{
-                .{ .x = absolute_point.x, .y = absolute_point.y + 1.0, .u = 0.0, .v = 1.0 },
-                .{ .x = absolute_point.x + 1.0, .y = absolute_point.y + 1.0, .u = 1.0, .v = 1.0 },
-                .{ .x = absolute_point.x + 1.0, .y = absolute_point.y, .u = 1.0, .v = 0.0 },
-                .{ .x = absolute_point.x, .y = absolute_point.y, .u = 0.0, .v = 0.0 },
-            };
+            for (&self.bounds, DEFAULT_BOUNDS) |*b, default| {
+                b.* = default;
+                b.x += absolute_point.x;
+                b.y += absolute_point.y;
+            }
 
             const new_path = try Path.new(.{ .x = 0.0, .y = 0.0 }, allocator);
             try self.paths.append(new_path);
@@ -130,33 +125,38 @@ pub const Shape = struct {
 
         if (active_path_index) |i| {
             var active_path = &self.paths.items[i];
-            if (!active_path.closed) {
-                try active_path.addPoint(point, getSnapThreshold(self.bounds));
-                try self.update_bounds(allocator, null);
-                return;
-            }
+            try active_path.addPoint(point, getSnapThreshold(self.bounds));
+        } else {
+            // start a new path
+            const new_path = try Path.new(point, allocator);
+            try self.paths.append(new_path);
+            active_path_index = self.paths.items.len - 1;
         }
-
-        // start a new path
-        const new_path = try Path.new(point, allocator);
-        try self.paths.append(new_path);
-        active_path_index = self.paths.items.len - 1;
-        try self.update_bounds(allocator, null);
     }
 
-    pub fn updatePointPreview(self: *Shape, x: f32, y: f32) !void {
-        const p = Point{ .x = x, .y = y };
+    pub fn updatePointPreview(self: *Shape, p: Point) !void {
         if (is_handle_preview) {
-            var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-            defer arena.deinit();
-            const allocator = arena.allocator();
-
-            try self.updateLastHandle(
-                allocator,
-                p,
-            );
+            try self.updateLastHandle(p);
+            self.outdated_sdf = true;
         } else {
-            preview_point = p;
+            self.update_preview_point(p);
+        }
+    }
+
+    // the point of this method is to limit sets of outdated_sdf to true
+    pub fn update_preview_point(self: *Shape, p: ?Point) void {
+        if (active_path_index == null) {
+            return;
+        }
+
+        const curr_preview = self.preview_point orelse Point{ .x = std.math.inf(f32), .y = 0 };
+        const new_preview = p orelse Point{ .x = std.math.inf(f32), .y = 0 };
+
+        const is_diff = !Utils.equalF32(curr_preview.x, new_preview.x) or !Utils.equalF32(curr_preview.y, new_preview.y);
+
+        if (is_diff) {
+            self.preview_point = p;
+            self.outdated_sdf = true;
         }
     }
 
@@ -171,7 +171,7 @@ pub const Shape = struct {
         const new_width = box.max_x - box.min_x;
         const new_height = box.max_y - box.min_y;
 
-        if (Utils.cmpF32(new_width, 0) or Utils.cmpF32(new_height, 0)) {
+        if (Utils.equalF32(new_width, 0) or Utils.equalF32(new_height, 0)) {
             return; // No valid bounding box
         }
 
@@ -194,7 +194,7 @@ pub const Shape = struct {
         };
     }
 
-    fn updateLastHandle(self: *Shape, allocator: std.mem.Allocator, absolute_point: Point) !void {
+    fn updateLastHandle(self: *Shape, absolute_point: Point) !void {
         if (active_path_index) |i| {
             const matrix = Matrix3x3.getMatrixFromRectangle(self.bounds);
             const point = matrix.inverse().get(absolute_point);
@@ -203,14 +203,23 @@ pub const Shape = struct {
             active_path.updateLastHandle(point);
 
             self.outdated_sdf = true;
-            try self.update_bounds(allocator, null);
         }
+    }
+
+    pub fn onReleasePointer(self: Shape) void {
+        if (active_path_index) |i| {
+            const active_path = self.paths.items[i];
+            if (active_path.closed) {
+                active_path_index = null;
+            }
+        }
+
+        is_handle_preview = false;
     }
 
     pub fn getSkeletonDrawVertexData(
         self: Shape,
         allocator: std.mem.Allocator,
-        is_active: bool,
     ) ![]triangles.DrawInstance {
         var skeleton_buffer = std.ArrayList(triangles.DrawInstance).init(allocator);
         const matrix = Matrix3x3.getMatrixFromRectangle(self.bounds);
@@ -220,12 +229,10 @@ pub const Shape = struct {
             try skeleton_buffer.appendSlice(path_skeleton);
         }
 
-        if (is_active) {
-            if (preview_point) |point| {
-                if (!is_handle_preview) {
-                    const buffer = Path.getVertexSkeletonPoint(true, point);
-                    try skeleton_buffer.appendSlice(&buffer);
-                }
+        if (self.preview_point) |point| {
+            if (!is_handle_preview) {
+                const buffer = Path.getVertexSkeletonPoint(true, point);
+                try skeleton_buffer.appendSlice(&buffer);
             }
         }
 
@@ -261,19 +268,21 @@ pub const Shape = struct {
 
     pub fn getUniform(self: Shape) Uniform {
         return Uniform{
-            .stroke_width = self.props.stroke_width,
+            .stroke_width = self.props.stroke_width / shared.render_scale,
             .fill_color = self.props.fill_color,
             .stroke_color = self.props.stroke_color,
         };
     }
 
-    pub fn getDrawVertexData(self: *Shape, allocator: std.mem.Allocator, is_active: bool) !?[]Point {
-        if (is_active and active_path_index != null and preview_point != null) {
-            try self.update_bounds(allocator, preview_point);
+    // function has side effect, marks texture as generated
+    pub fn getNewSdfPoint(self: *Shape, allocator: std.mem.Allocator) !?[]Point {
+        if (self.outdated_sdf) {
+            try self.update_bounds(allocator, self.preview_point);
         }
+
         const points = try self.getAllPoints(
             allocator,
-            if (is_active) preview_point else null,
+            self.preview_point,
             active_path_index,
         );
 
@@ -282,22 +291,24 @@ pub const Shape = struct {
         }
 
         const scale = Matrix3x3.scaling(
-            self.bounds[0].distance(self.bounds[1]),
-            self.bounds[0].distance(self.bounds[3]),
+            self.bounds[0].distance(self.bounds[1]) / shared.render_scale,
+            self.bounds[0].distance(self.bounds[3]) / shared.render_scale,
         );
 
-        const padding = self.props.stroke_width / 2.0;
+        const padding = (self.props.stroke_width / 2.0) / shared.render_scale;
         for (points) |*point| {
             const scaled = scale.get(point);
             point.x = padding + scaled.x;
             point.y = padding + scaled.y;
         }
 
+        self.outdated_sdf = false;
+
         return points;
     }
 
-    pub fn getBoundsWithPadding(self: Shape) [4]PointUV {
-        const padding = self.props.stroke_width / 2.0;
+    pub fn getBoundsWithPadding(self: Shape, scale: f32) [4]PointUV {
+        const padding = (self.props.stroke_width / 2.0);
         var buffer: [4]PointUV = undefined;
         const len = self.bounds.len;
 
@@ -311,13 +322,15 @@ pub const Shape = struct {
             buffer[i] = b;
             buffer[i].x -= @cos(angle_next) * padding + @cos(angle_prev) * padding;
             buffer[i].y -= @sin(angle_next) * padding + @sin(angle_prev) * padding;
+            buffer[i].x *= scale;
+            buffer[i].y *= scale;
         }
 
         return buffer;
     }
 
     pub fn getDrawBounds(self: Shape) [6]PointUV {
-        const bounds = self.getBoundsWithPadding();
+        const bounds = self.getBoundsWithPadding(1);
         return [_]PointUV{
             // first triangle
             bounds[0],

--- a/src/logic/shared.zig
+++ b/src/logic/shared.zig
@@ -1,1 +1,3 @@
 pub var render_scale: f32 = 1.0; // Global render scale
+pub var max_buffer_size: f32 = 0;
+pub var texture_max_size: f32 = 0;

--- a/src/logic/shared.zig
+++ b/src/logic/shared.zig
@@ -1,3 +1,3 @@
 pub var render_scale: f32 = 1.0; // Global render scale
-pub var max_buffer_size: f32 = 0;
-pub var texture_max_size: f32 = 0;
+pub var max_buffer_size: f32 = 0; // stores as float only to avoid constant casts
+pub var texture_max_size: f32 = 0; // stores as float only to avoid constant casts

--- a/src/logic/types.zig
+++ b/src/logic/types.zig
@@ -60,3 +60,8 @@ pub const PointUV = extern struct {
         return std.math.hypot(self.x - other.x, self.y - other.y);
     }
 };
+
+pub const TextureSize = struct {
+    w: u32,
+    h: u32,
+};

--- a/src/logic/utils.zig
+++ b/src/logic/utils.zig
@@ -16,6 +16,6 @@ pub fn getNextPowerOfTwo(value: f32) f32 {
 }
 
 const EPSILON = math.floatEps(f32);
-pub fn cmpF32(a: f32, b: f32) bool {
+pub fn equalF32(a: f32, b: f32) bool {
     return @abs(a - b) < EPSILON;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,7 +8,7 @@ import {
   canvasMatrixBuffer,
   pickCanvasMatrixBuffer,
   drawShape,
-  computeSDF,
+  computeShape,
   pickShape,
 } from 'WebGPU/programs/initPrograms'
 import getCanvasMatrix from 'getCanvasMatrix'
@@ -56,19 +56,10 @@ export default function runCreator(
       }
       */
     },
-    compute_shape: (curves_data, width, height, textureId) => {
+    compute_shape: (curves_data, width, height, distanceScaleFactor, textureId) => {
       const curvesDataView = curves_data['*'].dataView
       Textures.updateSDF(textureId, width, height)
-      computeSDF(computePass, curvesDataView, Textures.getTexture(textureId))
-      // drawShape(renderPass, curvesDataView, boundBoxDataView, uniform_data.dataView)
-
-      /*
-      samplesCount++
-      total += performance.now() - time
-      if (samplesCount % 100 === 0) {
-        console.log('Average draw time:', total / samplesCount)
-      }
-      */
+      computeShape(computePass, curvesDataView, distanceScaleFactor, Textures.getTexture(textureId))
     },
     draw_shape: (bound_box_data, uniform_data, textureId) => {
       const boundBoxDataView = bound_box_data['*'].dataView
@@ -76,12 +67,6 @@ export default function runCreator(
     },
     pick_texture: (vertex_data, texture_id) => {
       const dataView = vertex_data['*'].dataView
-      // const uints = new Uint32Array(
-      //   dataView.buffer.slice(dataView.byteOffset, dataView.byteOffset + dataView.byteLength)
-      // )
-      // for (let i = 0; i < uints.length; i += 5) {
-      //   console.log('texture id', uints[i + 4])
-      // }
       pickTexture(pickPass, dataView, Textures.getTextureSafe(texture_id))
     },
     pick_shape: (bound_box_data, uniform_data, textureId) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Distance scale control for shape computation; per-shape preview state.
  - New picking support for shapes and triangles.

- Performance
  - Per-shape SDF caching with selective recompute; automatic SDF texture sizing that respects device limits.

- Visual
  - Skeleton points scale with render scale; consistent skeleton stroke width.

- Bug Fixes
  - Avoids unintended pointer release when no shape is selected.

- Refactor
  - Compute pass renamed to "computeShape" and initialization now includes device buffer size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->