### PR TITLE
fix: scale of distance in sdfs

### DIFF
--- a/src/WebGPU/programs/computeShape/getProgram.ts
+++ b/src/WebGPU/programs/computeShape/getProgram.ts
@@ -17,7 +17,6 @@ export default function getComputeShape(device: GPUDevice, buffersToDestroy: GPU
   return function computeShape(
     passEncoder: GPUComputePassEncoder,
     curvesDataView: DataView,
-    distanceScaleFactor: number,
     texture: GPUTexture
   ) {
     const curvesBuffer = device.createBuffer({
@@ -28,14 +27,6 @@ export default function getComputeShape(device: GPUDevice, buffersToDestroy: GPU
     device.queue.writeBuffer(curvesBuffer, 0, curvesDataView)
     buffersToDestroy.push(curvesBuffer)
 
-    const uniformBuffer = device.createBuffer({
-      label: 'computeShape uniform buffer',
-      size: 4 /*scale*/ + 12 /*padding*/,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    })
-    device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([distanceScaleFactor]))
-    buffersToDestroy.push(uniformBuffer)
-
     passEncoder.setPipeline(pipeline)
 
     const bindGroup = device.createBindGroup({
@@ -43,7 +34,6 @@ export default function getComputeShape(device: GPUDevice, buffersToDestroy: GPU
       entries: [
         { binding: 0, resource: texture.createView() },
         { binding: 1, resource: { buffer: curvesBuffer } },
-        { binding: 2, resource: { buffer: uniformBuffer } },
       ],
     })
 

--- a/src/WebGPU/programs/computeShape/shader.wgsl
+++ b/src/WebGPU/programs/computeShape/shader.wgsl
@@ -1,5 +1,6 @@
 const STRAIGHT_LINE_THRESHOLD = 1e10;
 const EPSILON = 1e-10;
+const PI = 3.141592653589793;
 
 struct CubicBezier {
   p0: vec2f,
@@ -354,13 +355,15 @@ fn evaluate_shape(point: vec2f) -> ShapeInfo {
     curves[closest_curve_idx * 4 + 2],
     curves[closest_curve_idx * 4 + 3]
   );
+
+  // handling straight line case
   if (curve.p1.x > STRAIGHT_LINE_THRESHOLD) {
     curve.p1 = curve.p0;
     curve.p2 = curve.p3;
   }
 
   let closest_point = bezier_point(curve, closest_t);
-  let angle = 3.1415926 + atan2(point.y - closest_point.y, point.x - closest_point.x);
+  let angle = PI + atan2(point.y - closest_point.y, point.x - closest_point.x);
   
   // Determine if point is inside using odd-even rule (ray casting)
   // Count total crossings and check if odd

--- a/src/WebGPU/programs/computeShape/shader.wgsl
+++ b/src/WebGPU/programs/computeShape/shader.wgsl
@@ -8,13 +8,8 @@ struct CubicBezier {
   p3: vec2f,
 };
 
-struct Uniforms {
-  distance_scale: f32,
-};
-
 @group(0) @binding(0) var tex: texture_storage_2d<rgba32float, write>;
 @group(0) @binding(1) var<storage, read> curves: array<vec2f>;
-@group(0) @binding(2) var<uniform> u: Uniforms;
 
 @compute @workgroup_size(1) fn cs(
   @builtin(global_invocation_id) id : vec3u
@@ -23,7 +18,7 @@ struct Uniforms {
   let shape_info = evaluate_shape(pos);
 
   textureStore(tex, id.xy, vec4f(
-    shape_info.signed_distance * u.distance_scale,
+    shape_info.signed_distance,
     shape_info.t,
     shape_info.angle,
     1.0
@@ -302,8 +297,12 @@ fn evaluate_shape(point: vec2f) -> ShapeInfo {
       curves[i * 4 + 3]
     );
 
-    // Check if this is a straight line (handle points have x >= STRAIGHT_LINE_THRESHOLD)
-    let is_straight_line = curve.p1.x > STRAIGHT_LINE_THRESHOLD && curve.p2.x > STRAIGHT_LINE_THRESHOLD;
+    // Check if this is a straight line,
+    // we could check also p2, but at this point we should receive only
+    // straight line on both handles, not a case for just one straight handle,
+    // those are changed to have sibling cp value
+    let is_straight_line = curve.p1.x > STRAIGHT_LINE_THRESHOLD;
+    // let is_straight_line = curve.p1.x > STRAIGHT_LINE_THRESHOLD && curve.p2.x > STRAIGHT_LINE_THRESHOLD;
 
 
     if (is_straight_line) {
@@ -349,14 +348,19 @@ fn evaluate_shape(point: vec2f) -> ShapeInfo {
     // min_distance = min(min_distance, distance);
   }
 
-  let curve = CubicBezier(
+  var curve = CubicBezier(
     curves[closest_curve_idx * 4 + 0],
     curves[closest_curve_idx * 4 + 1],
     curves[closest_curve_idx * 4 + 2],
     curves[closest_curve_idx * 4 + 3]
   );
+  if (curve.p1.x > STRAIGHT_LINE_THRESHOLD) {
+    curve.p1 = curve.p0;
+    curve.p2 = curve.p3;
+  }
+
   let closest_point = bezier_point(curve, closest_t);
-  let angle = atan2(point.y - closest_point.y, point.x - closest_point.x);
+  let angle = 3.1415926 + atan2(point.y - closest_point.y, point.x - closest_point.x);
   
   // Determine if point is inside using odd-even rule (ray casting)
   // Count total crossings and check if odd

--- a/src/WebGPU/programs/drawShape/shader.wgsl
+++ b/src/WebGPU/programs/drawShape/shader.wgsl
@@ -1,5 +1,6 @@
 const STRAIGHT_LINE_THRESHOLD = 1e10;
 const EPSILON = 1e-10;
+const PI = 3.141592653589793;
 
 struct Uniforms {
   stroke_width: f32,
@@ -53,7 +54,7 @@ fn getSample(pos: vec2f) -> vec4f {
 
   let dist = sdf.r;
   let width = fwidth(dist);
-  
+
   let hs = u.stroke_width * 0.5;
 
   let fill_alpha = smoothstep(hs - width, hs + width, dist);
@@ -65,7 +66,7 @@ fn getSample(pos: vec2f) -> vec4f {
 
   // let stroke_factor = select(0.5, 0.0, sdf.g > 1.0);
   // color = vec4f(0, sdf.g % 1, 0, 1.0);
-  // color = vec4f(0, 0, sdf.b / (2 * 3.1415926), 1.0);
-  // color = vec4f(sdf.r / 100.0, sdf.g % 1, sdf.b / (2 * 3.1415926), 1.0);
+  // color = vec4f(0, 0, sdf.b / (2 * PI), 1.0);
+  // color = vec4f(sdf.r / 100.0, sdf.g % 1, sdf.b / (2 * PI), 1.0);
   // color = select(vec4f(0.5, 0, 0, 1), vec4f(0, 0, 0.5, 1), u32(sdf.r / 20.0) % 2 == 0);
 }

--- a/src/WebGPU/programs/drawShape/shader.wgsl
+++ b/src/WebGPU/programs/drawShape/shader.wgsl
@@ -28,8 +28,29 @@ struct VSOutput {
   );
 }
 
+fn getSample(pos: vec2f) -> vec4f {
+  let floor_pos = floor(pos - 0.5);
+  let fract_pos = pos - 0.5 - floor_pos;
+
+  let p00 = vec2u(floor_pos);
+  let p10 = vec2u(floor_pos + vec2f(1.0, 0.0));
+  let p01 = vec2u(floor_pos + vec2f(0.0, 1.0));
+  let p11 = vec2u(floor_pos + vec2f(1.0, 1.0));
+
+  let c00 = textureLoad(texture, p00);
+  let c10 = textureLoad(texture, p10);
+  let c01 = textureLoad(texture, p01);
+  let c11 = textureLoad(texture, p11);
+
+  let top = mix(c00, c10, fract_pos.x);
+  let bottom = mix(c01, c11, fract_pos.x);
+
+  return mix(top, bottom, fract_pos.y);
+}
+
 @fragment fn fs(vsOut: VSOutput) -> @location(0) vec4f {
-  let sdf = textureLoad(texture, vec2u(vsOut.uv));
+  let sdf = getSample(vsOut.uv);
+  // let sdf = textureLoad(texture, vec2u(vsOut.uv));
 
   // let stroke_factor = select(0.5, 0.0, sdf.g > 1.0);
   let stroke_factor = 0.5;

--- a/src/WebGPU/programs/drawShape/shader.wgsl
+++ b/src/WebGPU/programs/drawShape/shader.wgsl
@@ -50,17 +50,22 @@ fn getSample(pos: vec2f) -> vec4f {
 
 @fragment fn fs(vsOut: VSOutput) -> @location(0) vec4f {
   let sdf = getSample(vsOut.uv);
-  // let sdf = textureLoad(texture, vec2u(vsOut.uv));
+
+  let dist = sdf.r;
+  let width = fwidth(dist);
+  
+  let hs = u.stroke_width * 0.5;
+
+  let fill_alpha = smoothstep(hs - width, hs + width, dist);
+  let color = mix(u.stroke_color, u.fill_color, fill_alpha);
+
+  let total_alpha = smoothstep(-hs - width, -hs + width, dist);
+
+  return vec4f(color.rgb, color.a * total_alpha);
 
   // let stroke_factor = select(0.5, 0.0, sdf.g > 1.0);
-  let stroke_factor = 0.5;
-  let is_filled = select(0.0, 1.0, sdf.r > -u.stroke_width * stroke_factor);
-  var color = select(u.stroke_color, u.fill_color, sdf.r > u.stroke_width * stroke_factor);
-
   // color = vec4f(0, sdf.g % 1, 0, 1.0);
   // color = vec4f(0, 0, sdf.b / (2 * 3.1415926), 1.0);
   // color = vec4f(sdf.r / 100.0, sdf.g % 1, sdf.b / (2 * 3.1415926), 1.0);
   // color = select(vec4f(0.5, 0, 0, 1), vec4f(0, 0, 0.5, 1), u32(sdf.r / 20.0) % 2 == 0);
-
-  return color * is_filled;
 }

--- a/src/WebGPU/programs/drawShape/shader.wgsl
+++ b/src/WebGPU/programs/drawShape/shader.wgsl
@@ -32,11 +32,13 @@ struct VSOutput {
   let sdf = textureLoad(texture, vec2u(vsOut.uv));
 
   // let stroke_factor = select(0.5, 0.0, sdf.g > 1.0);
-  let stroke_factor = 0.0;
+  let stroke_factor = 0.5;
   let is_filled = select(0.0, 1.0, sdf.r > -u.stroke_width * stroke_factor);
   var color = select(u.stroke_color, u.fill_color, sdf.r > u.stroke_width * stroke_factor);
 
-  color = vec4f(sdf.r / 100.0, sdf.g % 1, sdf.b / (2 * 3.1415926), 1.0);
+  // color = vec4f(0, sdf.g % 1, 0, 1.0);
+  // color = vec4f(0, 0, sdf.b / (2 * 3.1415926), 1.0);
+  // color = vec4f(sdf.r / 100.0, sdf.g % 1, sdf.b / (2 * 3.1415926), 1.0);
   // color = select(vec4f(0.5, 0, 0, 1), vec4f(0, 0, 0.5, 1), u32(sdf.r / 20.0) % 2 == 0);
 
   return color * is_filled;

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -96,7 +96,6 @@ declare module '*.zig' {
       curves_data: ArrayPointerDataView,
       width: number,
       height: number,
-      distance_scale: number,
       texture_id: number
     ) => void
     draw_shape: (

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -19,7 +19,7 @@ const PathUtils = @import("shapes/path_utils.zig");
 const WebGpuPrograms = struct {
     draw_texture: *const fn (images.DrawVertex, u32) void,
     draw_triangle: *const fn ([]const Triangle.DrawInstance) void,
-    compute_shape: *const fn ([]const types.Point, u32, u32, f32, u32) void,
+    compute_shape: *const fn ([]const types.Point, u32, u32, u32) void,
     draw_shape: *const fn ([]const types.PointUV, shapes.Uniform, u32) void,
     draw_msdf: *const fn ([]const Msdf.DrawInstance, u32) void,
     pick_texture: *const fn ([]const images.PickVertex, u32) void,
@@ -610,20 +610,19 @@ pub fn calculateShapesSDF() !void {
                 const option_points = try shape.getNewSdfPoint(allocator);
                 if (option_points) |points| {
                     const bounds = shape.getBoundsWithPadding(1 / shared.render_scale);
-                    const init_width = bounds[0].distance(bounds[1]);
                     shape.sdf_size = get_sdf_texture_size(bounds);
-                    const scale = @as(f32, @floatFromInt(shape.sdf_size.w)) / init_width;
+                    const init_width = bounds[0].distance(bounds[1]) * shared.render_scale; // revert to logical scale, nothing screen/camera/zoom related
+                    shape.sdf_scale = @as(f32, @floatFromInt(shape.sdf_size.w)) / init_width;
 
                     for (points) |*point| {
-                        point.x *= scale;
-                        point.y *= scale;
+                        point.x *= shape.sdf_scale;
+                        point.y *= shape.sdf_scale;
                     }
-                    std.debug.print("New SDF size: {}x{}\n", .{ shape.sdf_size.w, shape.sdf_size.h });
+                    std.debug.print("New SDF size: {d}x{d}, scale: {d}\n", .{ shape.sdf_size.w, shape.sdf_size.h, shape.sdf_scale });
                     web_gpu_programs.compute_shape(
                         points,
                         shape.sdf_size.w,
                         shape.sdf_size.h,
-                        1 / scale,
                         shape.texture_id,
                     );
                 }
@@ -678,7 +677,7 @@ pub fn renderDraw() !void {
                 state.tool == Tool.DrawShape,
             );
             web_gpu_programs.draw_triangle(vertex_data);
-            web_gpu_programs.draw_shape(&shape.getDrawBounds(), shapes.getSkeletonUniform(), shape.texture_id);
+            web_gpu_programs.draw_shape(&shape.getDrawBounds(), shape.getSkeletonUniform(), shape.texture_id);
         }
     }
 

--- a/src/logic/shapes/path_utils.zig
+++ b/src/logic/shapes/path_utils.zig
@@ -55,6 +55,7 @@ pub fn getOppositeHandle(control_point: Point, handle: Point) Point {
 
 const SKELETON_POINT_SIZE = 10.0;
 const PICK_POINT_SCALE = 2.0;
+pub const SKELETON_LINE_WIDTH = 3.0;
 
 pub fn getVertexDrawSkeletonPoint(
     is_control_point: bool,
@@ -119,7 +120,7 @@ pub fn drawControlPoint(
                 local_buffer[0..2],
                 cp,
                 hp,
-                3.0 * shared.render_scale,
+                SKELETON_LINE_WIDTH * shared.render_scale,
                 [_]u8{ 0, 0, 255, 255 },
                 0.0,
             );

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -263,7 +263,7 @@ pub const Shape = struct {
 
     pub fn getSkeletonUniform(self: Shape) Uniform {
         return Uniform{
-            .stroke_width = 3.0 * self.sdf_scale * shared.render_scale,
+            .stroke_width = PathUtils.SKELETON_LINE_WIDTH * self.sdf_scale * shared.render_scale,
             .fill_color = .{ 0.0, 0.0, 0.0, 0.0 },
             .stroke_color = .{ 0.0, 0.0, 1.0, 1.0 },
         };

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -44,14 +44,6 @@ pub const Preview = struct {
     point: Point,
 };
 
-pub fn getSkeletonUniform() Uniform {
-    return Uniform{
-        .stroke_width = 2.0,
-        .fill_color = .{ 0.0, 0.0, 0.0, 0.0 },
-        .stroke_color = .{ 0.0, 0.0, 1.0, 1.0 },
-    };
-}
-
 fn getSnapThreshold(bounds: [4]PointUV) Point {
     const invert_matrix = Matrix3x3.getMatrixFromRectangle(bounds).inverse();
     const close_path_threshold = Point{
@@ -66,8 +58,11 @@ pub const Shape = struct {
     paths: std.ArrayList(Path),
     props: ShapeProps,
     bounds: [4]PointUV,
+
+    sdf_scale: f32 = 1.0,
     outdated_sdf: bool, // if true, we need to recalculate SDF
     texture_id: u32,
+
     preview_point: ?Point = null,
 
     sdf_size: TextureSize = .{ .w = 0, .h = 0 }, // stores the last size of computed sdf
@@ -266,6 +261,14 @@ pub const Shape = struct {
         return skeleton_buffer.toOwnedSlice();
     }
 
+    pub fn getSkeletonUniform(self: Shape) Uniform {
+        return Uniform{
+            .stroke_width = 3.0 * self.sdf_scale * shared.render_scale,
+            .fill_color = .{ 0.0, 0.0, 0.0, 0.0 },
+            .stroke_color = .{ 0.0, 0.0, 1.0, 1.0 },
+        };
+    }
+
     pub fn getSkeletonPickVertexData(
         self: Shape,
         allocator: std.mem.Allocator,
@@ -310,7 +313,7 @@ pub const Shape = struct {
 
     pub fn getUniform(self: Shape) Uniform {
         return Uniform{
-            .stroke_width = self.props.stroke_width / shared.render_scale,
+            .stroke_width = self.props.stroke_width * self.sdf_scale,
             .fill_color = self.props.fill_color,
             .stroke_color = self.props.stroke_color,
         };
@@ -343,11 +346,11 @@ pub const Shape = struct {
         }
 
         const scale = Matrix3x3.scaling(
-            self.bounds[0].distance(self.bounds[1]) / shared.render_scale,
-            self.bounds[0].distance(self.bounds[3]) / shared.render_scale,
+            self.bounds[0].distance(self.bounds[1]),
+            self.bounds[0].distance(self.bounds[3]),
         );
 
-        const padding = (self.props.stroke_width / 2.0) / shared.render_scale;
+        const padding = self.props.stroke_width / 2.0;
         for (points) |*point| {
             const scaled = scale.get(point);
             point.x = padding + scaled.x;

--- a/src/run.ts
+++ b/src/run.ts
@@ -56,10 +56,10 @@ export default function runCreator(
       }
       */
     },
-    compute_shape: (curves_data, width, height, distanceScaleFactor, textureId) => {
+    compute_shape: (curves_data, width, height, textureId) => {
       const curvesDataView = curves_data['*'].dataView
       Textures.updateSDF(textureId, width, height)
-      computeShape(computePass, curvesDataView, distanceScaleFactor, Textures.getTexture(textureId))
+      computeShape(computePass, curvesDataView, Textures.getTexture(textureId))
     },
     draw_shape: (bound_box_data, uniform_data, textureId) => {
       const boundBoxDataView = bound_box_data['*'].dataView

--- a/src/shapes/createShape.ts
+++ b/src/shapes/createShape.ts
@@ -13,7 +13,11 @@ export default function createShapes(node: Node, svgHeight: number): void {
     if (typeof child !== 'string') {
       if ('properties' in child && typeof child.properties === 'object') {
         const props = child.properties
-        const serializedProps: Partial<ShapeProps> = {}
+        const serializedProps: Partial<ShapeProps> = {
+          fill_color: [0, 0, 0, 1],
+          stroke_color: [1, 0, 0, 1],
+          stroke_width: 10,
+        }
         if (props.fill) {
           const rgba = parseColor(props.fill as string)
           serializedProps.fill_color = rgba


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New shapes default to black fill, red stroke, 10px stroke width.
  - Per-shape skeleton uniform and bilinear texture sampling for smoother rendering.

- Bug Fixes
  - Improved straight-segment detection and normalization for more accurate geometry.
  - Consistent stroke widths via per-shape SDF scaling; removed global distance scaling so signed-distance uses logical scale.

- Style
  - Distance-based stroke/fill shading and orientation handling refined for more predictable visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->