### PR TITLE
fix: split fill and stroke

### DIFF
--- a/src/WebGPU/programs/drawShape/base.wgsl
+++ b/src/WebGPU/programs/drawShape/base.wgsl
@@ -49,19 +49,14 @@ fn getSample(pos: vec2f) -> vec4f {
   let sdf = getSample(vsOut.uv);
 
   let dist = sdf.r;
-  let width = fwidth(dist);
+  let width = fwidth(dist) * 0.5;
 
-  let hs = u.stroke_width * 0.5;
+  let inner_alpha = smoothstep(u.dist_start - width, u.dist_start + width, dist);
+  let outer_alpha = smoothstep(u.dist_end - width, u.dist_end + width, dist);
+  let alpha = outer_alpha - inner_alpha;
+  let color = getColor(sdf, vsOut.uv, vsOut.norm_uv);
 
-  let fill_alpha = smoothstep(hs - width, hs + width, dist);
-  let fill_color = getFillColor(sdf, vsOut.uv, vsOut.norm_uv);
-  let stroke_color = getStrokeColor(sdf, vsOut.uv, vsOut.norm_uv);
-  let color = mix(stroke_color, fill_color, fill_alpha);
-
-  let total_alpha = smoothstep(-hs - width, -hs + width, dist);
-
-  // return vec4f(color.rgb, color.a * total_alpha);
-  return vec4f(fill_color.rgb, fill_color.a * fill_alpha);
+  return vec4f(color.rgb, color.a * alpha);
   // let result = vec4f(fill_color.rgb, fill_color.a * fill_alpha);
   // if (result.a < 0.5) {
   //   return vec4f(1, 0, 0, 1);

--- a/src/WebGPU/programs/drawShape/linear-gradient.wgsl
+++ b/src/WebGPU/programs/drawShape/linear-gradient.wgsl
@@ -4,9 +4,10 @@ struct Stop {
 }
 
 struct Uniform {
-  stroke_width: f32,
+  dist_start: f32,
+  dist_end: f32,
   stops_count: u32,
-  padding: vec2f, // Padding for alignment
+  padding: u32, // Padding for alignment
   start: vec2f,
   end: vec2f,
   stops: array<Stop, 10>,
@@ -14,11 +15,8 @@ struct Uniform {
 
 @group(0) @binding(0) var<uniform> u: Uniform;
 
-fn getStrokeColor(sdf: vec4f, uv: vec2f, norm_uv: vec2f) -> vec4f {
-  return vec4f(1, 1, 1, 1);
-}
 
-fn getFillColor(sdf: vec4f, world_uv: vec2f, uv: vec2f) -> vec4f {
+fn getColor(sdf: vec4f, world_uv: vec2f, uv: vec2f) -> vec4f {
   // Fallbacks
   if (u.stops_count == 0u) {
     return vec4f(1.0, 1.0, 1.0, 1.0);

--- a/src/WebGPU/programs/drawShape/radial-gradient.wgsl
+++ b/src/WebGPU/programs/drawShape/radial-gradient.wgsl
@@ -4,10 +4,10 @@ struct Stop {
 }
 
 struct Uniform {
-  stroke_width: f32,
+  dist_start: f32,
+  dist_end: f32,
   stops_count: u32,
   radius_ratio: f32, // vertical radius / horizontal radius (to create ellipse)
-  padding: u32,
   center: vec2f,    // Center point of radial gradient
   destination: vec2f,    // because we have scale, the angle between center an destination is visible in the gradient!
   stops: array<Stop, 10>,
@@ -15,11 +15,7 @@ struct Uniform {
 
 @group(0) @binding(0) var<uniform> u: Uniform;
 
-fn getStrokeColor(sdf: vec4f, uv: vec2f, norm_uv: vec2f) -> vec4f {
-  return vec4f(1, 1, 1, 1);
-}
-
-fn getFillColor(sdf: vec4f, world_uv: vec2f, uv: vec2f) -> vec4f {
+fn getColor(sdf: vec4f, world_uv: vec2f, uv: vec2f) -> vec4f {
   // Fallbacks
   if (u.stops_count == 0u) {
     return vec4f(1.0, 1.0, 1.0, 1.0);

--- a/src/WebGPU/programs/drawShape/solid.wgsl
+++ b/src/WebGPU/programs/drawShape/solid.wgsl
@@ -1,16 +1,13 @@
 
 struct Uniforms {
-  stroke_width: f32,
-  fill_color: vec4f,
-  stroke_color: vec4f,
+  dist_start: f32,
+  dist_end: f32,
+  padding: vec2f, // Padding for alignment
+  color: vec4f,
 };
 
 @group(0) @binding(0) var<uniform> u: Uniforms;
 
-fn getStrokeColor(sdf: vec4f, uv: vec2f, norm_uv: vec2f) -> vec4f {
-  return u.stroke_color;
-}
-
-fn getFillColor(sdf: vec4f, uv: vec2f, norm_uv: vec2f) -> vec4f {
-  return u.fill_color;
+fn getColor(sdf: vec4f, uv: vec2f, norm_uv: vec2f) -> vec4f {
+  return u.color;
 }

--- a/src/WebGPU/programs/initPrograms.ts
+++ b/src/WebGPU/programs/initPrograms.ts
@@ -74,15 +74,16 @@ export default function initPrograms(device: GPUDevice, presentationFormat: GPUT
     device,
     presentationFormat,
     solidFS,
-    1 /*stroke width*/ + 4 /*stroke color*/ + 4 /*fill color*/ + /*padding*/ 3
+    1 /*dist_start*/ + 1 /*dist_end*/ + 2 /*padding*/ + 4 /*color*/
   )
   drawLinearGradientShape = getDrawShape(
     device,
     presentationFormat,
     linearGradientFS,
-    1 /*stroke width*/ +
+    1 /*dist_start*/ +
+      1 /*dist_end*/ +
       1 /*stops counts*/ +
-      2 /*padding*/ +
+      1 /*padding*/ +
       2 /*start*/ +
       2 /*end*/ +
       (4 /*color*/ + 1 /*offset*/ + 3) /*padding*/ * 10 /*stops*/
@@ -91,9 +92,10 @@ export default function initPrograms(device: GPUDevice, presentationFormat: GPUT
     device,
     presentationFormat,
     radialGradientFS,
-    1 /*stroke width*/ +
-      1 /*stops counts*/ +
-      2 /*padding*/ +
+    1 /*dist_start*/ +
+      1 /*dist_end*/ +
+      1 /*stops_count*/ +
+      1 /*radius_ratio*/ +
       2 /*start*/ +
       2 /*end*/ +
       (4 /*color*/ + 1 /*offset*/ + 3) /*padding*/ * 10 /*stops*/

--- a/src/WebGPU/programs/pickShape/getProgram.ts
+++ b/src/WebGPU/programs/pickShape/getProgram.ts
@@ -41,17 +41,17 @@ export default function getDrawShape(device: GPUDevice, matrixBuffer: GPUBuffer)
   return function pickShape(
     pass: GPURenderPassEncoder,
     vertexData: DataView,
-    strokeWidth: number,
+    uniformData: DataView,
     sdfTexture: GPUTexture
   ) {
     const numVertices = vertexData.byteLength / STRIDE
 
     const uniformBuffer = device.createBuffer({
       label: 'drawShape uniforms',
-      size: uniformBufferSize,
+      size: uniformData.byteLength,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     })
-    device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([strokeWidth]))
+    device.queue.writeBuffer(uniformBuffer, 0, uniformData)
     delayedDestroy(uniformBuffer)
 
     const vertexBuffer = device.createBuffer({
@@ -60,6 +60,7 @@ export default function getDrawShape(device: GPUDevice, matrixBuffer: GPUBuffer)
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     })
     device.queue.writeBuffer(vertexBuffer, 0, vertexData)
+    delayedDestroy(vertexBuffer)
 
     // Get or create bind group for this texture
     const bindGroup = device.createBindGroup({

--- a/src/WebGPU/programs/pickShape/shader.wgsl
+++ b/src/WebGPU/programs/pickShape/shader.wgsl
@@ -37,7 +37,7 @@ struct VertexOutput {
   let dist = textureLoad(texture, vec2u(in.uv)).r;
 
   if (dist > u.dist_start || dist < u.dist_end) {
-    discard; // outside the outer boundary
+    discard;
   }
 
   return in.id;

--- a/src/WebGPU/programs/pickShape/shader.wgsl
+++ b/src/WebGPU/programs/pickShape/shader.wgsl
@@ -7,7 +7,8 @@ struct Vertex {
 };
 
 struct Uniforms {
-  stroke_width: f32,
+  dist_start: f32,
+  dist_end: f32,
 };
 
 @group(0) @binding(0) var<uniform> camera_projection: mat4x4f;
@@ -33,9 +34,10 @@ struct VertexOutput {
 }
 
 @fragment fn fs(in: VertexOutput) -> @location(0) u32 {
-  let sdf = textureLoad(texture, vec2u(in.uv)).r;
-  if (sdf < -u.stroke_width * 0.5) {
-    discard; // r32uint doesn't support blending so only skipping pixels lefts
+  let dist = textureLoad(texture, vec2u(in.uv)).r;
+
+  if (dist > u.dist_start || dist < u.dist_end) {
+    discard; // outside the outer boundary
   }
 
   return in.id;

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ export default async function initCreator(
             sdf_effects: [...shape.props.sdf_effects].map((effect) => ({
               dist_start: effect.dist_start,
               dist_end: effect.dist_end,
-              fill: sanitizeFill(effect.fill), // TODO: correctly filter out zigar added properties
+              fill: sanitizeFill(effect.fill),
             })),
             filter: shape.props.filter?.gaussianBlur
               ? {

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,9 +178,11 @@ export default async function initCreator(
             v: point.v,
           })),
           props: {
-            fill: sanitizeFill(shape.props.fill), // TODO: correctly filter out zigar added properties
-            stroke: sanitizeFill(shape.props.stroke), // TODO: correctly filter out zigar added properties
-            stroke_width: shape.props.stroke_width,
+            sdf_effects: [...shape.props.sdf_effects].map((effect) => ({
+              dist_start: effect.dist_start,
+              dist_end: effect.dist_end,
+              fill: sanitizeFill(effect.fill), // TODO: correctly filter out zigar added properties
+            })),
             filter: shape.props.filter?.gaussianBlur
               ? {
                   gaussianBlur: {

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -37,10 +37,14 @@ type RadialGradient = {
   destination: Point
 }
 
-type ShapeProps = {
-  stroke_width: number
+type SdfEffect = {
+  dist_start: number
+  dist_end: number
   fill: { linear: LinearGradient } | { radial: RadialGradient } | { solid: Color }
-  stroke: { linear: LinearGradient } | { radial: RadialGradient } | { solid: Color }
+}
+
+type ShapeProps = {
+  sdf_effects: SdfEffect[]
   filter: { gaussianBlur: Point } | null
   opacity: number
 }
@@ -57,7 +61,7 @@ type ShapeAssetOutput = {
   props: ShapeProps
   bounds: PointUV[]
   sdf_texture_id: number
-  cache_texture_id: number
+  cache_texture_id: number | null
 }
 type ImageAssetInput = {
   id: number
@@ -84,7 +88,7 @@ type PointerDataView = {
   dataView: DataView
 }
 
-type Uniform =
+type ShapeDrawUniform =
   | { solid: PointerDataView }
   | { linear: PointerDataView }
   | { radial: PointerDataView }
@@ -141,12 +145,12 @@ declare module '*.zig' {
     ) => void
     draw_shape: (
       bound_box_data: ArrayPointerDataView,
-      uniformData: Uniform,
+      uniformData: ShapeDrawUniform,
       sdf_texture_id: number
     ) => void
     pick_shape: (
       bound_box_data: ArrayPointerDataView,
-      strokeWidth: number,
+      uniformData: PointerDataView,
       sdf_texture_id: number
     ) => void
   }) => void

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -28,11 +28,11 @@ const WebGpuPrograms = struct {
     draw_triangle: *const fn ([]const Triangle.DrawInstance) void,
     compute_shape: *const fn ([]const types.Point, f32, f32, u32) void,
     draw_blur: *const fn (u32, u32, u32, u32, f32, f32) void,
-    draw_shape: *const fn ([]const types.PointUV, shapes.Uniform, u32) void,
+    draw_shape: *const fn ([]const types.PointUV, shapes.DrawUniform, u32) void,
     draw_msdf: *const fn ([]const Msdf.DrawInstance, u32) void,
     pick_texture: *const fn ([]const images.PickVertex, u32) void,
     pick_triangle: *const fn ([]const Triangle.PickInstance) void,
-    pick_shape: *const fn ([]const images.PickVertex, f32, u32) void,
+    pick_shape: *const fn ([]const images.PickVertex, shapes.PickUniform, u32) void,
 };
 var web_gpu_programs: *const WebGpuPrograms = undefined;
 
@@ -229,7 +229,7 @@ fn checkAssetsUpdate(should_notify: bool) !void {
             },
             .shape => |shape| {
                 try new_assets_update.append(AssetSerialized{
-                    .shape = try shape.serialize(),
+                    .shape = try shape.serialize(std.heap.page_allocator),
                 });
             },
         }
@@ -306,10 +306,24 @@ pub fn onPointerDown(x: f32, y: f32) !void {
     if (state.tool == Tool.DrawShape) {
         if (state.selected_asset_id == NO_SELECTION) {
             const props = shapes.SerializedProps{
-                .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
-                .stroke = .{ .solid = .{ 0.0, 0.0, 0.0, 1.0 } },
-                .stroke_width = 1.0,
-                .filter = .{ .gaussianBlur = .{ .x = 30, .y = 1 } },
+                .sdf_effects = &.{
+                    shapes.SerializedSdfEffect{
+                        .dist_start = 2,
+                        .dist_end = -2,
+                        .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
+                    },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = 26,
+                        .dist_end = 24,
+                        .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+                    },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = -30,
+                        .dist_end = -32,
+                        .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+                    },
+                },
+                .filter = null, // .{ .gaussianBlur = .{ .x = 30, .y = 1 } },
                 .opacity = 1.0,
             };
             const id = try addShape(
@@ -703,11 +717,13 @@ pub fn updateCache() void {
                         .{ .x = 0, .y = 0, .u = 0, .v = 0 },
                     };
 
-                    web_gpu_programs.draw_shape(
-                        &vertex_bounds,
-                        shape.getUniform(),
-                        shape.sdf_texture_id,
-                    );
+                    for (shape.props.sdf_effects.items) |effect| {
+                        web_gpu_programs.draw_shape(
+                            &vertex_bounds,
+                            shape.getDrawUniform(effect),
+                            shape.sdf_texture_id,
+                        );
+                    }
 
                     end_cache();
 
@@ -765,11 +781,13 @@ pub fn renderDraw() !void {
                         cache_texture_id,
                     );
                 } else {
-                    web_gpu_programs.draw_shape(
-                        &shape.getDrawBounds(true),
-                        shape.getUniform(),
-                        shape.sdf_texture_id,
-                    );
+                    for (shape.props.sdf_effects.items) |effect| {
+                        web_gpu_programs.draw_shape(
+                            &shape.getDrawBounds(true),
+                            shape.getDrawUniform(effect),
+                            shape.sdf_texture_id,
+                        );
+                    }
                 }
             },
         }
@@ -856,11 +874,13 @@ pub fn renderPick() !void {
                 web_gpu_programs.pick_texture(&vertex_data, img.texture_id);
             },
             .shape => |shape| {
-                web_gpu_programs.pick_shape(
-                    &shape.getPickBounds(),
-                    shape.getStrokeWidth(),
-                    shape.sdf_texture_id,
-                );
+                for (shape.props.sdf_effects.items) |effect| {
+                    web_gpu_programs.pick_shape(
+                        &shape.getPickBounds(),
+                        shape.getPickUniform(effect),
+                        shape.sdf_texture_id,
+                    );
+                }
             },
         }
     }

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -394,7 +394,6 @@ pub const Shape = struct {
                         },
                     };
                 }
-                // const half_stroke_width = self.getStrokeWidth() * 0.5;
                 return DrawUniform{
                     .linear = .{
                         .dist_start = sdf_effect.dist_start * self.sdf_scale,

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -47,21 +47,29 @@ fn getSnapThreshold(bounds: [4]PointUV) Point {
     return close_path_threshold;
 }
 
+pub const SdfEffect = struct {
+    dist_start: f32,
+    dist_end: f32,
+    fill: fill.Fill,
+};
+
+pub const SerializedSdfEffect = struct {
+    dist_start: f32,
+    dist_end: f32,
+    fill: fill.SerializedFill,
+};
+
 pub const Filter = struct {
     gaussianBlur: Point,
 };
 
 pub const Props = struct {
-    fill: fill.Fill,
-    stroke: fill.Fill,
-    stroke_width: f32,
+    sdf_effects: std.ArrayList(SdfEffect),
     filter: ?Filter,
     opacity: f32,
 };
 pub const SerializedProps = struct {
-    fill: fill.SerializedFill,
-    stroke: fill.SerializedFill,
-    stroke_width: f32,
+    sdf_effects: []const SerializedSdfEffect,
     filter: ?Filter,
     opacity: f32,
 };
@@ -104,10 +112,17 @@ pub const Shape = struct {
             try paths_list.append(path);
         }
 
+        var effects_list = std.ArrayList(SdfEffect).init(allocator);
+        for (input_props.sdf_effects) |effect| {
+            try effects_list.append(SdfEffect{
+                .dist_start = effect.dist_start,
+                .dist_end = effect.dist_end,
+                .fill = try fill.Fill.new(effect.fill, allocator),
+            });
+        }
+
         const props = Props{
-            .fill = try fill.Fill.new(input_props.fill, allocator),
-            .stroke = try fill.Fill.new(input_props.stroke, allocator),
-            .stroke_width = input_props.stroke_width,
+            .sdf_effects = effects_list,
             .filter = input_props.filter,
             .opacity = input_props.opacity,
         };
@@ -290,12 +305,13 @@ pub const Shape = struct {
         return skeleton_buffer.toOwnedSlice();
     }
 
-    pub fn getSkeletonUniform(self: Shape) Uniform {
-        return Uniform{
+    pub fn getSkeletonUniform(self: Shape) DrawUniform {
+        const stroke_width = PathUtils.SKELETON_LINE_WIDTH * self.sdf_scale * shared.render_scale;
+        return DrawUniform{
             .solid = .{
-                .stroke_width = PathUtils.SKELETON_LINE_WIDTH * self.sdf_scale * shared.render_scale,
-                .fill_color = .{ 0.0, 0.0, 0.0, 0.0 },
-                .stroke_color = .{ 0.0, 0.0, 1.0, 1.0 },
+                .dist_start = stroke_width * 0.5,
+                .dist_end = -stroke_width * 0.5,
+                .color = .{ 0.0, 0.0, 1.0, 1.0 },
             },
         };
     }
@@ -342,23 +358,26 @@ pub const Shape = struct {
         return points.toOwnedSlice();
     }
 
-    pub fn getStrokeWidth(self: Shape) f32 {
-        return self.props.stroke_width * self.sdf_scale;
+    pub fn getPickUniform(self: Shape, sdf_effect: SdfEffect) PickUniform {
+        return PickUniform{
+            .dist_start = sdf_effect.dist_start * self.sdf_scale,
+            .dist_end = sdf_effect.dist_end * self.sdf_scale,
+        };
     }
 
-    pub fn getUniform(self: Shape) Uniform {
-        switch (self.props.fill) {
+    pub fn getDrawUniform(self: Shape, sdf_effect: SdfEffect) DrawUniform {
+        switch (sdf_effect.fill) {
             .solid => |color| {
-                return Uniform{
+                return DrawUniform{
                     .solid = .{
-                        .stroke_width = self.getStrokeWidth(),
-                        .fill_color = .{
+                        .dist_start = sdf_effect.dist_start * self.sdf_scale,
+                        .dist_end = sdf_effect.dist_end * self.sdf_scale,
+                        .color = .{
                             color[0] * self.props.opacity,
                             color[1] * self.props.opacity,
                             color[2] * self.props.opacity,
                             color[3] * self.props.opacity,
                         },
-                        .stroke_color = .{ 0, 0, 0, 0 }, //self.props.stroke_color,
                     },
                 };
             },
@@ -375,10 +394,11 @@ pub const Shape = struct {
                         },
                     };
                 }
-
-                return Uniform{
+                // const half_stroke_width = self.getStrokeWidth() * 0.5;
+                return DrawUniform{
                     .linear = .{
-                        .stroke_width = self.getStrokeWidth(),
+                        .dist_start = sdf_effect.dist_start * self.sdf_scale,
+                        .dist_end = sdf_effect.dist_end * self.sdf_scale,
                         .stops_count = gradient.stops.items.len,
                         .start = gradient.start,
                         .end = gradient.end,
@@ -400,9 +420,10 @@ pub const Shape = struct {
                     };
                 }
 
-                return Uniform{
+                return DrawUniform{
                     .radial = .{
-                        .stroke_width = self.getStrokeWidth(),
+                        .dist_start = sdf_effect.dist_start * self.sdf_scale,
+                        .dist_end = sdf_effect.dist_end * self.sdf_scale,
                         .stops_count = gradient.stops.items.len,
                         .center = gradient.center,
                         .destination = gradient.destination,
@@ -520,22 +541,43 @@ pub const Shape = struct {
     }
 
     fn getSdfPadding(self: Shape) Point {
-        return Point{
-            .x = 1.0 + self.props.stroke_width / 2.0,
-            .y = 1.0 + self.props.stroke_width / 2.0,
-        };
+        var padding = consts.POINT_ZERO;
+        // because of skeleton render, we cannot od less than zero
+
+        for (self.props.sdf_effects.items) |effect| {
+            if (std.math.isInf(effect.dist_end)) {
+                std.debug.print("SDF effect dist_end cannot be infinite!\nShape ID: {d}, effect: {any}\n", .{ self.id, effect });
+                @panic("SDF effect dist_end cannot be infinite!");
+            }
+            padding.x = @max(padding.x, -effect.dist_end);
+            padding.y = @max(padding.y, -effect.dist_end);
+        }
+
+        // we do smoothing in shaders wit fwidth(), so it's 1px to make sure we wont cut it out
+        padding.x += 1.0;
+        padding.y += 1.0;
+
+        return padding;
     }
 
-    pub fn serialize(self: Shape) !Serialized {
-        var paths_list = std.ArrayList([]const Point).init(self.paths.allocator);
+    pub fn serialize(self: Shape, allocator: std.mem.Allocator) !Serialized {
+        var paths_list = std.ArrayList([]const Point).init(allocator);
         for (self.paths.items) |path| {
             const serialized_path = path.serialize();
             try paths_list.append(serialized_path);
         }
+
+        var effects_list = std.ArrayList(SerializedSdfEffect).init(allocator);
+        for (self.props.sdf_effects.items) |effect| {
+            try effects_list.append(SerializedSdfEffect{
+                .dist_start = effect.dist_start,
+                .dist_end = effect.dist_end,
+                .fill = effect.fill.serialize(),
+            });
+        }
+
         const props = SerializedProps{
-            .fill = self.props.fill.serialize(),
-            .stroke = self.props.stroke.serialize(),
-            .stroke_width = self.props.stroke_width,
+            .sdf_effects = try effects_list.toOwnedSlice(),
             .filter = self.props.filter,
             .opacity = self.props.opacity,
         };
@@ -561,10 +603,10 @@ pub const Shape = struct {
 };
 
 const UniformSolid = extern struct {
-    stroke_width: f32,
-    padding: [3]f32 = .{ 0.0, 0.0, 0.0 }, // Padding for alignment
-    fill_color: [4]f32,
-    stroke_color: [4]f32,
+    dist_start: f32,
+    dist_end: f32,
+    padding: [2]u32 = .{ 0, 0 },
+    color: [4]f32,
 };
 
 const UniformGradientStop = extern struct {
@@ -574,28 +616,34 @@ const UniformGradientStop = extern struct {
 };
 
 const UniformLinearGradient = extern struct {
-    stroke_width: f32,
+    dist_start: f32,
+    dist_end: f32,
     stops_count: u32,
-    padding: [2]f32 = .{ 0.0, 0.0 }, // Padding for alignment
+    padding: u32 = 0.0,
     start: Point,
     end: Point,
     stops: [10]UniformGradientStop,
 };
 
 const UniformRadialGradient = extern struct {
-    stroke_width: f32,
+    dist_start: f32,
+    dist_end: f32,
     stops_count: u32,
     radius_ratio: f32,
-    padding: u32 = 0, // Padding for alignment
     center: Point,
     destination: Point, // rx, ry for elliptical gradients
     stops: [10]UniformGradientStop,
 };
 
-pub const Uniform = union(enum) {
+pub const DrawUniform = union(enum) {
     solid: UniformSolid,
     linear: UniformLinearGradient,
     radial: UniformRadialGradient,
+};
+
+pub const PickUniform = struct {
+    dist_start: f32,
+    dist_end: f32,
 };
 
 pub const Serialized = struct {

--- a/src/run.ts
+++ b/src/run.ts
@@ -117,8 +117,13 @@ export default function runCreator(
       const dataView = vertex_data['*'].dataView
       pickTexture(pickPass, dataView, Textures.getTextureSafe(texture_id))
     },
-    pick_shape: (bound_box_data, strokeWidth, textureId) => {
-      pickShape(pickPass, bound_box_data['*'].dataView, strokeWidth, Textures.getTexture(textureId))
+    pick_shape: (bound_box_data, uniform, textureId) => {
+      pickShape(
+        pickPass,
+        bound_box_data['*'].dataView,
+        uniform.dataView,
+        Textures.getTexture(textureId)
+      )
     },
     pick_triangle: (vertex_data) => {
       const dataView = vertex_data['*'].dataView

--- a/src/sanitizeFill.ts
+++ b/src/sanitizeFill.ts
@@ -1,4 +1,4 @@
-export default function sanitizeFill(fill: ShapeProps['fill']): ShapeProps['fill'] {
+export default function sanitizeFill(fill: SdfEffect['fill']): SdfEffect['fill'] {
   if ('solid' in fill && fill.solid) {
     return { solid: [...fill.solid] }
   }

--- a/src/svgToShapes/definitions.ts
+++ b/src/svgToShapes/definitions.ts
@@ -41,6 +41,7 @@ export type Def = {
   filter?: AttrValue
   opacity?: AttrValue
   'fill-opacity'?: AttrValue
+  'stroke-width'?: AttrValue
 }
 
 export type Defs = Record<string, Def>

--- a/src/svgToShapes/index.ts
+++ b/src/svgToShapes/index.ts
@@ -28,7 +28,7 @@ function toRuntimeGradient(
   def: Def,
   boundingBox: BoundingBox,
   overrideAlpha = 1
-): ShapeProps['fill'] | null {
+): SdfEffect['fill'] | null {
   if (def.type !== 'linear-gradient' && def.type !== 'radial-gradient') {
     console.error('toRuntimeGradient receive definition which is not a gradient!')
     return null
@@ -190,10 +190,8 @@ export function createShapes(
       if (paths) {
         const boundingBox = getBoundingBox(paths)
 
-        const serializedProps: Partial<ShapeProps> = {
-          fill: { solid: [0, 0, 0, 1] },
-          stroke: { solid: [0, 0, 0, 1] },
-          stroke_width: 0,
+        const serializedProps: ShapeProps = {
+          sdf_effects: [],
           filter: null,
           opacity: 1,
         }
@@ -202,32 +200,58 @@ export function createShapes(
           const fillOpacity = ensureNumber(props['fill-opacity'], 1)
           const fill = String(props.fill)
           const m = fill.match(/^url\(#([^)]+)\)$/)
+          let serializedFill: SdfEffect['fill'] | null = null
 
           if (m) {
             const def = defs[m[1]]
             if (def) {
               const grad = toRuntimeGradient(def, boundingBox, fillOpacity)
-              if (grad) serializedProps.fill = grad
+              if (grad) {
+                serializedFill = grad
+              }
             }
           } else {
             const rgba = parseColor(fill, fillOpacity)
-            serializedProps.fill = { solid: rgba }
+            serializedFill = { solid: rgba }
+          }
+
+          if (serializedFill) {
+            serializedProps.sdf_effects.push({
+              dist_start: Infinity,
+              dist_end: 0,
+              fill: serializedFill,
+            })
           }
         }
-        if (props.stroke) {
-          const stroke = String(props.stroke)
-          const m = stroke.match(/^url\(#([^)]+)\)$/)
+
+        if (props['stroke-width']) {
+          const color = String(props.stroke) || '#000'
+          const width = ensureNumber(props['stroke-width'], 1)
+          const m = color.match(/^url\(#([^)]+)\)$/)
+          let serializedFill: SdfEffect['fill'] | null = null
+
           if (m) {
             const def = defs[m[1]]
             if (def) {
               const grad = toRuntimeGradient(def, boundingBox)
-              if (grad) serializedProps.stroke = grad
+              if (grad) {
+                serializedFill = grad
+              }
             }
           } else {
-            const rgba = parseColor(stroke)
-            serializedProps.stroke = { solid: rgba }
+            const rgba = parseColor(color)
+            serializedFill = { solid: rgba }
+          }
+
+          if (serializedFill) {
+            serializedProps.sdf_effects.push({
+              dist_start: width / 2,
+              dist_end: -width / 2,
+              fill: serializedFill,
+            })
           }
         }
+
         if (props.filter) {
           const filter = String(props.filter)
           const m = filter.match(/^url\(#([^)]+)\)$/)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support multiple SDF effects per shape (layered fills with distance ranges).
  - SVG import now recognizes stroke-width.

- Improvements
  - Smoother edges via refined anti-aliasing.
  - Unified color handling across solid and gradient fills.
  - Picking and rendering respect per-effect styling.

- Refactor
  - Shape props serialization now emits sdf_effects instead of top-level fill/stroke/stroke_width.
  - Picking and draw pipelines accept uniform data for effects-driven rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->