### PR TITLE
feat: provide text as one sdf

### DIFF
--- a/ADRs/sdf per char of per text
+++ b/ADRs/sdf per char of per text
@@ -1,0 +1,27 @@
+We have two ways of drawing text:
+a) Each char has dedicated SDF, and we draw one by one SDFs to draw the whole text
+pros:
+
+- in most cases uses less memory because all textures are unique(except cases where effect-padding is huge)
+- allows us to create effect where each char should have own dedicated SDF(not like distance field should be based on all chars)
+
+cons:
+
+- to create effect where all chars impact SDF we would have to use depth-buffer and pass length there and use shorter length
+- complex calculations, we need to have use max size of requested font but ALSO max size of requested effect-padding -> also at point where sdf max size is reached we have to decide to decrease effect-padding or font-size! Probably font-size is the one that has to be decreased - we might also make it more dynamic(depends on zoom and we can cut out effect if not visible for user) or we might generate more than one SDF
+- how do we deal with two different usages of the same char. One has huge effect-padding and the other one is just huge and has zero effect-padding.
+
+b) One SDF per text
+pros:
+
+- effects where SDF depends on all chars distance
+- simpler calculations because we don't have to maintain list of sdf for each char, and calculate their font-size, effect-padding
+- if effect requires large effect-padding, then this solution can use less memory
+
+cons:
+
+- to calculate effect where SDF depends on individual chars, we would need to render separated SDF anyway
+- might be heavy to compute SDF if there are gonna be a lot of chars/curves in the text
+
+Conclusions:
+Maybe we should use the first way to create SDF, and then treat it as a shape? Because blur also needs to be handled!

--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -25,6 +25,7 @@ async function test() {
   const redoBtn = document.querySelector<HTMLSpanElement>('#redo-btn')!
   const toolsSelect = document.querySelector<HTMLSelectElement>('#tools-select')!
   const previewImg = document.querySelector<HTMLImageElement>('#preview')!
+  const sharedTextEffects = document.querySelector<HTMLInputElement>('#shared-text-effects')!
 
   window.assetsSnapshot = []
   function setAssetSnapshot(assets: SerializedOutputAsset[]) {
@@ -160,6 +161,10 @@ async function test() {
   toolsSelect.addEventListener('change', (event) => {
     const selectedTool = Number((event.target as HTMLSelectElement).value)
     creator.setTool(selectedTool)
+  })
+
+  sharedTextEffects.addEventListener('change', () => {
+    creator.toggleSharedTextEffects()
   })
 }
 

--- a/integration-tests/template.html
+++ b/integration-tests/template.html
@@ -55,6 +55,9 @@
       </select>
     </div>
     <div>
+      <label>Shared text effects<input type="checkbox" id="shared-text-effects" /></label>
+    </div>
+    <div>
       <img id="preview" style="width: 100%; height: auto; aspect-ratio: 1; display: block;" />
     </div>
   </aside>

--- a/src/WebGPU/pick.ts
+++ b/src/WebGPU/pick.ts
@@ -88,7 +88,7 @@ export default class PickManager {
     return { pass, end: endPicking }
   }
 
-  createMatrix(canvas: HTMLCanvasElement, canvasMatrix: Float32Array) {
+  createMatrix(canvas: HTMLCanvasElement, canvasMatrix: Float32Array<ArrayBuffer>) {
     const tx = -(2 * (pointer.x / canvas.width) - 1)
     const ty = 2 * (pointer.y / canvas.height) - 1
 

--- a/src/WebGPU/programs/clearComputeDepth/getProgram.ts
+++ b/src/WebGPU/programs/clearComputeDepth/getProgram.ts
@@ -1,0 +1,34 @@
+import shaderCode from './shader.wgsl'
+
+export default function getClearComputeDepth(device: GPUDevice) {
+  const shaderModule = device.createShaderModule({
+    label: 'fill texture with max float shader module',
+    code: shaderCode,
+  })
+
+  const pipeline = device.createComputePipeline({
+    layout: 'auto',
+    compute: {
+      module: shaderModule,
+    },
+  })
+
+  return function clearComputeDepth(passEncoder: GPUComputePassEncoder, texture: GPUTexture) {
+    const bindGroup = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: texture.createView(),
+        },
+      ],
+    })
+
+    passEncoder.setPipeline(pipeline)
+    passEncoder.setBindGroup(0, bindGroup)
+
+    // const workgroupsX = Math.ceil(width / 8 )
+    // const workgroupsY = Math.ceil(height / 8)
+    passEncoder.dispatchWorkgroups(texture.width, texture.height)
+  }
+}

--- a/src/WebGPU/programs/clearComputeDepth/shader.wgsl
+++ b/src/WebGPU/programs/clearComputeDepth/shader.wgsl
@@ -1,0 +1,6 @@
+@group(0) @binding(0) var texture: texture_storage_2d<r32float, write>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3u) {
+    textureStore(texture, id.xy, vec4f(-3.402823466e+38));
+}

--- a/src/WebGPU/programs/clearSdf/getProgram.ts
+++ b/src/WebGPU/programs/clearSdf/getProgram.ts
@@ -1,0 +1,34 @@
+import shaderCode from './shader.wgsl'
+
+export default function getCombineSdf(device: GPUDevice) {
+  const shaderModule = device.createShaderModule({
+    label: 'fill texture with max float shader module',
+    code: shaderCode,
+  })
+
+  const pipeline = device.createComputePipeline({
+    layout: 'auto',
+    compute: {
+      module: shaderModule,
+    },
+  })
+
+  return function clearSdf(passEncoder: GPUComputePassEncoder, texture: GPUTexture) {
+    const bindGroup = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: texture.createView(),
+        },
+      ],
+    })
+
+    passEncoder.setPipeline(pipeline)
+    passEncoder.setBindGroup(0, bindGroup)
+
+    // const workgroupsX = Math.ceil(width / 8 )
+    // const workgroupsY = Math.ceil(height / 8)
+    passEncoder.dispatchWorkgroups(texture.width, texture.height)
+  }
+}

--- a/src/WebGPU/programs/clearSdf/getProgram.ts
+++ b/src/WebGPU/programs/clearSdf/getProgram.ts
@@ -1,6 +1,6 @@
 import shaderCode from './shader.wgsl'
 
-export default function getCombineSdf(device: GPUDevice) {
+export default function getClearSdf(device: GPUDevice) {
   const shaderModule = device.createShaderModule({
     label: 'fill texture with max float shader module',
     code: shaderCode,

--- a/src/WebGPU/programs/clearSdf/shader.wgsl
+++ b/src/WebGPU/programs/clearSdf/shader.wgsl
@@ -1,0 +1,6 @@
+@group(0) @binding(0) var texture: texture_storage_2d<rgba32float, write>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3u) {
+    textureStore(texture, id.xy, vec4f(-3.402823466e+38));
+}

--- a/src/WebGPU/programs/combineSdf/getProgram.ts
+++ b/src/WebGPU/programs/combineSdf/getProgram.ts
@@ -23,7 +23,7 @@ export default function getCombineSdf(device: GPUDevice) {
     placementData: DataView<ArrayBuffer> // [placement_start_x, placement_start_y, placement_end_x, placement_end_y]
   ) {
     const uniformBuffer = device.createBuffer({
-      label: 'computeShape curves buffer',
+      label: 'combine sdf uniform buffer',
       size: placementData.byteLength,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     })

--- a/src/WebGPU/programs/combineSdf/getProgram.ts
+++ b/src/WebGPU/programs/combineSdf/getProgram.ts
@@ -1,0 +1,51 @@
+import { delayedDestroy } from '../initPrograms'
+import shaderCode from './shader.wgsl'
+
+export default function getCombineSdf(device: GPUDevice) {
+  const shaderModule = device.createShaderModule({
+    label: 'combineSdf shader',
+    code: shaderCode,
+  })
+
+  const pipeline = device.createComputePipeline({
+    label: 'combineSdf pipeline',
+    layout: 'auto',
+    compute: {
+      module: shaderModule,
+    },
+  })
+
+  return function combineSdf(
+    passEncoder: GPUComputePassEncoder,
+    destinationTex: GPUTexture,
+    sourceTex: GPUTexture,
+    computeDepthTex: GPUTexture,
+    placementData: DataView<ArrayBuffer> // [placement_start_x, placement_start_y, placement_end_x, placement_end_y]
+  ) {
+    const uniformBuffer = device.createBuffer({
+      label: 'computeShape curves buffer',
+      size: placementData.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    })
+    device.queue.writeBuffer(uniformBuffer, 0, placementData)
+    delayedDestroy(uniformBuffer)
+
+    passEncoder.setPipeline(pipeline)
+
+    const bindGroup = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: destinationTex.createView() },
+        { binding: 1, resource: sourceTex.createView() },
+        { binding: 2, resource: computeDepthTex.createView() },
+        { binding: 3, resource: { buffer: uniformBuffer } },
+      ],
+    })
+
+    passEncoder.setBindGroup(0, bindGroup)
+    const width = placementData.getFloat32(2 * 4, true) - placementData.getFloat32(0 * 4, true)
+    const height = placementData.getFloat32(3 * 4, true) - placementData.getFloat32(1 * 4, true)
+
+    passEncoder.dispatchWorkgroups(width, height)
+  }
+}

--- a/src/WebGPU/programs/combineSdf/getProgram.ts
+++ b/src/WebGPU/programs/combineSdf/getProgram.ts
@@ -43,9 +43,9 @@ export default function getCombineSdf(device: GPUDevice) {
     })
 
     passEncoder.setBindGroup(0, bindGroup)
-    const width = placementData.getFloat32(2 * 4, true) - placementData.getFloat32(0 * 4, true)
-    const height = placementData.getFloat32(3 * 4, true) - placementData.getFloat32(1 * 4, true)
 
+    const width = placementData.getFloat32(2 * 4, true)
+    const height = placementData.getFloat32(3 * 4, true)
     passEncoder.dispatchWorkgroups(width, height)
   }
 }

--- a/src/WebGPU/programs/combineSdf/shader.wgsl
+++ b/src/WebGPU/programs/combineSdf/shader.wgsl
@@ -21,10 +21,11 @@ struct Uniform {
   let depth = textureLoad(depth_tex, dest_pos).r;
   let ratio_source_tex_to_placement = vec2f(textureDimensions(source_tex)) / u.placement_size; // texture doesn't to be same size as placement_size!
   let source_texel = getSample(texel_pos * ratio_source_tex_to_placement);
+  let scaled_dist = source_texel.r / ratio_source_tex_to_placement.x; // we assume all sizes keeps their ratio width / height, so we can use .x or .y here
 
-  if (source_texel.r > depth){
-    textureStore(destination_tex, dest_pos, source_texel);
-    textureStore(depth_tex, dest_pos, vec4f(source_texel.r));
+  if (scaled_dist > depth){
+    textureStore(destination_tex, dest_pos, vec4f(scaled_dist, source_texel.g, source_texel.b, source_texel.a));
+    textureStore(depth_tex, dest_pos, vec4f(scaled_dist));
   }
 }
 

--- a/src/WebGPU/programs/combineSdf/shader.wgsl
+++ b/src/WebGPU/programs/combineSdf/shader.wgsl
@@ -1,6 +1,6 @@
 struct Uniform {
   placement_start: vec2f,
-  placement_end: vec2f, // not used!
+  placement_size: vec2f,
 };
 
 @group(0) @binding(0) var destination_tex: texture_storage_2d<rgba32float, write>;
@@ -11,15 +11,16 @@ struct Uniform {
 @compute @workgroup_size(1) fn cs(
   @builtin(global_invocation_id) id : vec3u
 )  {
-  let source_pos = vec2f(id.xy) + vec2f(0.5);
+  let texel_pos = vec2f(id.xy) + vec2f(0.5);
 
-  let dest_pos = vec2i(u.placement_start + source_pos);
+  let dest_pos = vec2i(u.placement_start + texel_pos);
   if (any(dest_pos < vec2i(0)) || any(dest_pos >= vec2i(textureDimensions(destination_tex)))) {
     return;
   }
 
   let depth = textureLoad(depth_tex, dest_pos).r;
-  let source_texel = getSample(source_pos);
+  let ratio_source_tex_to_placement = vec2f(textureDimensions(source_tex)) / u.placement_size; // texture doesn't to be same size as placement_size!
+  let source_texel = getSample(texel_pos * ratio_source_tex_to_placement);
 
   if (source_texel.r > depth){
     textureStore(destination_tex, dest_pos, source_texel);

--- a/src/WebGPU/programs/combineSdf/shader.wgsl
+++ b/src/WebGPU/programs/combineSdf/shader.wgsl
@@ -18,8 +18,8 @@ struct Uniform {
     return;
   }
 
-  let depth = textureLoad(depth_tex, dest_pos).r;
   let ratio_source_tex_to_placement = vec2f(textureDimensions(source_tex)) / u.placement_size; // texture doesn't to be same size as placement_size!
+  let depth = textureLoad(depth_tex, dest_pos).r;
   let source_texel = getSample(texel_pos * ratio_source_tex_to_placement);
   let scaled_dist = source_texel.r / ratio_source_tex_to_placement.x; // we assume all sizes keeps their ratio width / height, so we can use .x or .y here
 
@@ -31,7 +31,7 @@ struct Uniform {
 
 fn getSample(pos: vec2f) -> vec4f {
   let floor_pos = floor(pos - 0.5);
-  let fract_pos = pos - 0.5 - floor_pos;
+  let fract_pos = (pos - 0.5) - floor_pos;
 
   let p00 = vec2u(floor_pos);
   let p10 = vec2u(floor_pos + vec2f(1.0, 0.0));

--- a/src/WebGPU/programs/combineSdf/shader.wgsl
+++ b/src/WebGPU/programs/combineSdf/shader.wgsl
@@ -1,0 +1,48 @@
+struct Uniform {
+  placement_start: vec2f,
+  placement_end: vec2f, // not used!
+};
+
+@group(0) @binding(0) var destination_tex: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(1) var source_tex: texture_storage_2d<rgba32float, read>;
+@group(0) @binding(2) var depth_tex: texture_storage_2d<r32float, read_write>;
+@group(0) @binding(3) var<uniform> u: Uniform;
+
+@compute @workgroup_size(1) fn cs(
+  @builtin(global_invocation_id) id : vec3u
+)  {
+  let source_pos = vec2f(id.xy) + vec2f(0.5);
+
+  let dest_pos = vec2i(u.placement_start + source_pos);
+  if (any(dest_pos < vec2i(0)) || any(dest_pos >= vec2i(textureDimensions(destination_tex)))) {
+    return;
+  }
+
+  let depth = textureLoad(depth_tex, dest_pos).r;
+  let source_texel = getSample(source_pos);
+
+  if (source_texel.r > depth){
+    textureStore(destination_tex, dest_pos, source_texel);
+    textureStore(depth_tex, dest_pos, vec4f(source_texel.r));
+  }
+}
+
+fn getSample(pos: vec2f) -> vec4f {
+  let floor_pos = floor(pos - 0.5);
+  let fract_pos = pos - 0.5 - floor_pos;
+
+  let p00 = vec2u(floor_pos);
+  let p10 = vec2u(floor_pos + vec2f(1.0, 0.0));
+  let p01 = vec2u(floor_pos + vec2f(0.0, 1.0));
+  let p11 = vec2u(floor_pos + vec2f(1.0, 1.0));
+
+  let c00 = textureLoad(source_tex, p00);
+  let c10 = textureLoad(source_tex, p10);
+  let c01 = textureLoad(source_tex, p01);
+  let c11 = textureLoad(source_tex, p11);
+
+  let top = mix(c00, c10, fract_pos.x);
+  let bottom = mix(c01, c11, fract_pos.x);
+
+  return mix(top, bottom, fract_pos.y);
+}

--- a/src/WebGPU/programs/computeShape/shader.wgsl
+++ b/src/WebGPU/programs/computeShape/shader.wgsl
@@ -15,7 +15,7 @@ struct CubicBezier {
 @compute @workgroup_size(1) fn cs(
   @builtin(global_invocation_id) id : vec3u
 )  {
-  let pos = vec2f(id.xy);
+  let pos = vec2f(id.xy) + vec2f(0.5, 0.5);
   let shape_info = evaluate_shape(pos);
 
   textureStore(tex, id.xy, vec4f(

--- a/src/WebGPU/programs/drawShape/base.wgsl
+++ b/src/WebGPU/programs/drawShape/base.wgsl
@@ -46,8 +46,8 @@ fn getSample(pos: vec2f) -> vec4f {
 
 
 @fragment fn fs(vsOut: VSOutput) -> @location(0) vec4f {
-  let sdf = textureLoad(texture, vec2u(vsOut.uv));
-  // let sdf = getSample(vsOut.uv);
+  // let sdf = textureLoad(texture, vec2u(vsOut.uv));
+  let sdf = getSample(vsOut.uv);
 
   let dist = sdf.r;
   let width = fwidth(dist) * 0.5;

--- a/src/WebGPU/programs/drawShape/base.wgsl
+++ b/src/WebGPU/programs/drawShape/base.wgsl
@@ -58,15 +58,11 @@ fn getSample(pos: vec2f) -> vec4f {
   let color = getColor(sdf, vsOut.uv, vsOut.norm_uv);
   let result = vec4f(color.rgb, color.a * alpha);
 
-  // if (result.a < 0.1) {
-  //   return vec4f(1, 0, 0, 0.1);
-  // }
+  if (dist < -99999) {
+    return vec4f(0, 0, 0, 1);
+  }
 
-  return vec4f(dist * 0.3, 0, abs(dist) / 20, 1);
-
-
-  // 181.72799682617188 183.0240020751953 -69.40799713134766
-  // 31.24798583984375 112.31999969482422 214.27198791503906
+  // return vec4f(dist, 0, abs(dist) / 20, 1);
 
   return result;
 

--- a/src/WebGPU/programs/drawShape/base.wgsl
+++ b/src/WebGPU/programs/drawShape/base.wgsl
@@ -58,12 +58,6 @@ fn getSample(pos: vec2f) -> vec4f {
   let color = getColor(sdf, vsOut.uv, vsOut.norm_uv);
   let result = vec4f(color.rgb, color.a * alpha);
 
-  if (dist < -99999) {
-    return vec4f(0, 0, 0, 1);
-  }
-
-  // return vec4f(dist, 0, abs(dist) / 20, 1);
-
   return result;
 
   // let stroke_factor = select(0.5, 0.0, sdf.g > 1.0);

--- a/src/WebGPU/programs/drawShape/base.wgsl
+++ b/src/WebGPU/programs/drawShape/base.wgsl
@@ -56,11 +56,18 @@ fn getSample(pos: vec2f) -> vec4f {
   let outer_alpha = smoothstep(u.dist_end - width, u.dist_end + width, dist);
   let alpha = outer_alpha - inner_alpha;
   let color = getColor(sdf, vsOut.uv, vsOut.norm_uv);
-
   let result = vec4f(color.rgb, color.a * alpha);
-  if (result.a < 0.001) {
-    return vec4f(1, 0, 0, 0.1);
-  }
+
+  // if (result.a < 0.1) {
+  //   return vec4f(1, 0, 0, 0.1);
+  // }
+
+  return vec4f(dist * 0.3, 0, abs(dist) / 20, 1);
+
+
+  // 181.72799682617188 183.0240020751953 -69.40799713134766
+  // 31.24798583984375 112.31999969482422 214.27198791503906
+
   return result;
 
   // let stroke_factor = select(0.5, 0.0, sdf.g > 1.0);

--- a/src/WebGPU/programs/drawShape/base.wgsl
+++ b/src/WebGPU/programs/drawShape/base.wgsl
@@ -46,7 +46,8 @@ fn getSample(pos: vec2f) -> vec4f {
 
 
 @fragment fn fs(vsOut: VSOutput) -> @location(0) vec4f {
-  let sdf = getSample(vsOut.uv);
+  let sdf = textureLoad(texture, vec2u(vsOut.uv));
+  // let sdf = getSample(vsOut.uv);
 
   let dist = sdf.r;
   let width = fwidth(dist) * 0.5;
@@ -57,9 +58,9 @@ fn getSample(pos: vec2f) -> vec4f {
   let color = getColor(sdf, vsOut.uv, vsOut.norm_uv);
 
   let result = vec4f(color.rgb, color.a * alpha);
-  // if (result.a < 0.001) {
-  //   return vec4f(1, 0, 0, 0.1);
-  // }
+  if (result.a < 0.001) {
+    return vec4f(1, 0, 0, 0.5);
+  }
   return result;
 
   // let stroke_factor = select(0.5, 0.0, sdf.g > 1.0);

--- a/src/WebGPU/programs/drawShape/base.wgsl
+++ b/src/WebGPU/programs/drawShape/base.wgsl
@@ -59,7 +59,7 @@ fn getSample(pos: vec2f) -> vec4f {
 
   let result = vec4f(color.rgb, color.a * alpha);
   if (result.a < 0.001) {
-    return vec4f(1, 0, 0, 0.5);
+    return vec4f(1, 0, 0, 0.1);
   }
   return result;
 

--- a/src/WebGPU/programs/initPrograms.ts
+++ b/src/WebGPU/programs/initPrograms.ts
@@ -9,6 +9,9 @@ import linearGradientFS from './drawShape/linear-gradient.wgsl'
 import radialGradientFS from './drawShape/radial-gradient.wgsl'
 import getPickShape from './pickShape/getProgram'
 import getComputeShape from './computeShape/getProgram'
+import getCombineSdf from './combineSdf/getProgram'
+import getClearComputeDepth from './clearComputeDepth/getProgram'
+import getClearSdf from './clearSdf/getProgram'
 
 export let drawTriangle: ReturnType<typeof getDrawTriangle>
 export let drawBlur: ReturnType<typeof getBlur>
@@ -20,6 +23,9 @@ export let drawLinearGradientShape: ReturnType<typeof getDrawShape>
 export let drawRadialGradientShape: ReturnType<typeof getDrawShape>
 export let pickShape: ReturnType<typeof getPickShape>
 export let computeShape: ReturnType<typeof getComputeShape>
+export let combineSdf: ReturnType<typeof getCombineSdf>
+export let clearComputeDepth: ReturnType<typeof getClearComputeDepth>
+export let clearSdf: ReturnType<typeof getClearSdf>
 
 export const canvasMatrix: {
   buffer: GPUBuffer
@@ -87,4 +93,7 @@ export default function initPrograms(device: GPUDevice, presentationFormat: GPUT
   )
   pickShape = getPickShape(device, pickCanvasMatrixBuffer)
   computeShape = getComputeShape(device)
+  combineSdf = getCombineSdf(device)
+  clearComputeDepth = getClearComputeDepth(device)
+  clearSdf = getClearSdf(device)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type SerializedInputText = {
   content: string
   bounds: PointUV[]
   font_size: number
+  props: ShapeProps
 }
 
 export type SerializedInputAsset = SerializedInputImage | SerializedInputShape | SerializedInputText
@@ -58,6 +59,7 @@ export type SerializedOutputText = {
   content: string
   bounds: PointUV[]
   font_size: number
+  props: ShapeProps
 }
 
 export type SerializedOutputAsset =
@@ -203,22 +205,7 @@ export default async function initCreator(
             u: point.u,
             v: point.v,
           })),
-          props: {
-            sdf_effects: [...shape.props.sdf_effects].map((effect) => ({
-              dist_start: effect.dist_start,
-              dist_end: effect.dist_end,
-              fill: sanitizeFill(effect.fill),
-            })),
-            filter: shape.props.filter?.gaussianBlur
-              ? {
-                  gaussianBlur: {
-                    x: shape.props.filter.gaussianBlur.x,
-                    y: shape.props.filter.gaussianBlur.y,
-                  },
-                }
-              : null,
-            opacity: shape.props.opacity,
-          },
+          props: serializeShapeProps(shape.props),
           sdf_texture_id: shape.sdf_texture_id,
           cache_texture_id: shape.cache_texture_id,
         }
@@ -233,6 +220,7 @@ export default async function initCreator(
             v: point.v,
           })),
           font_size: asset.text.font_size,
+          props: serializeShapeProps(asset.text.props),
         }
       } else {
         throw Error('Unknown asset type')
@@ -244,7 +232,7 @@ export default async function initCreator(
   Fonts.loadFont()
 
   Logic.connectOnAssetSelectionCallback(onAssetSelect)
-  Logic.connectCreateSdfTexture(Textures.createSDF)
+  Logic.connectCreateSdfTexture(Textures.createSDF, Textures.createComputeDepthTexture)
   Logic.connectTyping(
     Typing.enable,
     Typing.disable,
@@ -298,6 +286,7 @@ export default async function initCreator(
                   content: asset.content,
                   bounds: asset.bounds,
                   font_size: asset.font_size,
+                  props: asset.props,
                 },
               })
             }
@@ -355,5 +344,24 @@ export default async function initCreator(
       device.destroy()
     },
     setTool: Logic.setTool,
+  }
+}
+
+function serializeShapeProps(props: ShapeProps): ShapeProps {
+  return {
+    sdf_effects: [...props.sdf_effects].map((effect) => ({
+      dist_start: effect.dist_start,
+      dist_end: effect.dist_end,
+      fill: sanitizeFill(effect.fill),
+    })),
+    filter: props.filter?.gaussianBlur
+      ? {
+          gaussianBlur: {
+            x: props.filter.gaussianBlur.x,
+            y: props.filter.gaussianBlur.y,
+          },
+        }
+      : null,
+    opacity: props.opacity,
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export interface CreatorAPI {
   removeAsset: VoidFunction
   destroy: VoidFunction
   setTool: (tool: CreatorTool) => void
+  toggleSharedTextEffects: VoidFunction
 }
 
 const NO_ASSET_ID = 0 // used when we don't have asset id yet
@@ -344,6 +345,7 @@ export default async function initCreator(
       device.destroy()
     },
     setTool: Logic.setTool,
+    toggleSharedTextEffects: Logic.toggleSharedTextEffects,
   }
 }
 

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -63,6 +63,7 @@ type TextAsset = {
   content: string | null
   bounds: PointUV[]
   font_size: number
+  props: ShapeProps
 }
 
 type ShapeAsset = {
@@ -174,6 +175,18 @@ declare module '*.zig' {
       height: number,
       sdf_texture_id: number
     ) => void
+    clear_sdf: (
+      sdfTextureId: number,
+      computeDepthTextureId: number,
+      width: number,
+      height: number
+    ) => void
+    combine_sdf: (
+      destinatioTexId: number,
+      sourceTexId: number,
+      computeDepthTextureId: number,
+      uniformData: ArrayPointerDataView
+    ) => void
     draw_shape: (
       bound_box_data: ArrayPointerDataView,
       uniformData: ShapeDrawUniform,
@@ -187,7 +200,10 @@ declare module '*.zig' {
   }) => void
   export const connectOnAssetUpdateCallback: (cb: (data: ZigAsset[]) => void) => void
   export const connectOnAssetSelectionCallback: (cb: (data: Id) => void) => void
-  export const connectCreateSdfTexture: (cb: () => number) => void
+  export const connectCreateSdfTexture: (
+    createSdfTexture: () => number,
+    createComputeDepthTexture: (width: number, height: number) => number
+  ) => void
   export const connectCacheCallbacks: (
     create_cache_texture: () => number,
     start_cache: (texture_id: number, box: BoundingBox, width: number, height: number) => void,

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -182,7 +182,7 @@ declare module '*.zig' {
       height: number
     ) => void
     combine_sdf: (
-      destinatioTexId: number,
+      destinationTexId: number,
       sourceTexId: number,
       computeDepthTextureId: number,
       uniformData: PointerDataView

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -204,7 +204,7 @@ declare module '*.zig' {
   export const setCaretPosition: (selection_start: number, selection_end: number) => void
 
   export const tick: (time: DOMHighResTimeStamp) => void
-  export const calculateShapesSDF: VoidFunction
+  export const computeSdfs: VoidFunction
   export const renderDraw: VoidFunction
   export const renderPick: VoidFunction
   export const deinitState: VoidFunction

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -233,5 +233,5 @@ declare module '*.zig' {
   ) => void
   export const generateUiElementsSdf: VoidFunction
 
-  // export const page_allocator:
+  export const toggleSharedTextEffects: VoidFunction
 }

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -185,7 +185,7 @@ declare module '*.zig' {
       destinatioTexId: number,
       sourceTexId: number,
       computeDepthTextureId: number,
-      uniformData: ArrayPointerDataView
+      uniformData: PointerDataView
     ) => void
     draw_shape: (
       bound_box_data: ArrayPointerDataView,

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1013,8 +1013,8 @@ pub fn computeSdfs() !void {
                                 const placement = Placement{
                                     .x = (text_padding + start_x) * text.sdf_scale,
                                     .y = (text_padding + start_y) * text.sdf_scale,
-                                    .width = (text_padding + end_x - start_x) * text.sdf_scale,
-                                    .height = (text_padding + end_y - start_y) * text.sdf_scale,
+                                    .width = (end_x - start_x) * text.sdf_scale,
+                                    .height = (end_y - start_y) * text.sdf_scale,
                                 };
 
                                 web_gpu_programs.combine_sdf(

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -829,7 +829,7 @@ pub fn computeSdfs() !void {
                     shape.sdf_size = texture_size.get_allowed_sdf_size(desired_size);
 
                     const init_width = bounds[0].distance(bounds[1]) * shared.render_scale; // this multiplication is weird
-                    // * shared.render_scale to revert to logical scale, without impact of camera/zoom
+                    // * shared.render_scale to revert to logical scale (without impact of camera/zoom)
 
                     shape.sdf_scale = shape.sdf_size.w / init_width;
 
@@ -869,8 +869,8 @@ pub fn computeSdfs() !void {
                 const logical_w = d.max_requested_font_size * d.width + 2 * d.max_requested_effect_padding;
                 const logical_h = d.max_requested_font_size * d.height + 2 * d.max_requested_effect_padding;
                 const viewport_desired_size = texture_size.TextureSize{
-                    .w = logical_w, // / shared.render_scale,
-                    .h = logical_h, // / shared.render_scale,
+                    .w = logical_w,
+                    .h = logical_h,
                 };
 
                 const sdf_size = texture_size.get_allowed_sdf_size(
@@ -881,7 +881,7 @@ pub fn computeSdfs() !void {
                 const height_sdf_size = @ceil(sdf_size.h);
 
                 const sdf_scale = width_sdf_size / viewport_desired_size.w;
-
+                d.sdf_scale = width_sdf_size / (viewport_desired_size.w * shared.render_scale);
                 // d.paths_container_width = d.max_requested_font_size * d.width * sdf_scale;
                 // d.paths_container_height = d.max_requested_font_size * d.height * sdf_scale;
                 // d.effect_padding = d.max_requested_effect_padding
@@ -1049,26 +1049,30 @@ pub fn renderDraw() !void {
                     std.ArrayList(triangles.DrawInstance).init(allocator);
                 const matrix = Matrix3x3.getMatrixFromRectangleNoScale(text.bounds);
 
-                const uniform = sdf.DrawUniform{
-                    .solid = .{
-                        .dist_start = 2,
-                        .dist_end = -2,
-                        .color = .{ 0.9, 0.9, 0, 1 },
-                    },
-                };
-
                 for (text.text_vertex.items, 0..) |vertex, i| {
                     if (vertex.char) |char| {
-                        const char_details = try fonts.get(
+                        const char_details = try fonts.get_with_sdf(
                             0,
                             char,
-                            text.font_size,
-                            sdf.getSdfPadding(text.sdf_effects.items),
+                            text.font_size / shared.render_scale,
+                            sdf.getSdfPadding(text.sdf_effects.items) / shared.render_scale,
                         );
-
+                        // std.debug.print("font_size: {d}, padding: {d}\n", .{
+                        //     text.font_size / shared.render_scale,
+                        //     sdf.getSdfPadding(text.sdf_effects.items) / shared.render_scale,
+                        // });
+                        // std.debug.print("char_details.sdf_scale: {d}\n", .{char_details.sdf_scale});
                         if (char_details.sdf_texture_id) |sdf_texture_id| {
-                            const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
                             const scale_size_to_padding = char_details.max_requested_effect_padding / (char_details.max_requested_font_size * char_details.width);
+                            const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
+
+                            const uniform = sdf.DrawUniform{
+                                .solid = .{
+                                    .dist_start = 2 * char_details.sdf_scale,
+                                    .dist_end = -2 * char_details.sdf_scale,
+                                    .color = .{ 0.9, 0.9, 0, 1 },
+                                },
+                            };
 
                             web_gpu_programs.draw_shape(
                                 &vertex.getBounds(width * scale_size_to_padding, matrix),

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -29,7 +29,7 @@ const FillType = enum(u8) {
 const WebGpuPrograms = struct {
     draw_texture: *const fn ([]const types.PointUV, u32) void,
     draw_triangle: *const fn ([]const triangles.DrawInstance) void,
-    compute_shape: *const fn ([]const types.Point, f32, f32, u32) void,
+    compute_shape: *const fn ([]const types.Point, u32, u32, u32) void,
     draw_blur: *const fn (u32, u32, u32, u32, f32, f32) void,
     draw_shape: *const fn ([]const types.PointUV, sdf.DrawUniform, u32) void,
     pick_texture: *const fn ([]const images.PickVertex, u32) void,
@@ -190,7 +190,11 @@ pub fn updateRenderScale(scale: f32) !void {
             .img => {},
             .shape => |*shape| {
                 const bounds = shape.getBoundsWithPadding(1 / shared.render_scale, false);
-                const new_size = texture_size.get_sdf_size(bounds);
+                const desired_size = texture_size.get_allowed_size(
+                    bounds[0].distance(bounds[1]),
+                    bounds[0].distance(bounds[3]),
+                );
+                const new_size = texture_size.get_allowed_sdf_size(desired_size);
 
                 if (new_size.w > shape.sdf_size.w or new_size.h > shape.sdf_size.h) {
                     shape.outdated_sdf = true;
@@ -417,7 +421,8 @@ pub fn onPointerDown(x: f32, y: f32) !void {
 
             const new_text = try addText(
                 id,
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                "o",
+                // "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 bounds,
                 72.0,
             );
@@ -795,7 +800,7 @@ fn drawProjectBoundary() void {
     web_gpu_programs.draw_triangle(&buffer);
 }
 
-pub fn calculateShapesSDF() !void {
+pub fn computeSdfs() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -811,15 +816,19 @@ pub fn calculateShapesSDF() !void {
                 const do_update = shape.outdated_sdf or (shape.should_update_sdf and is_throttle_event);
                 if (!do_update) continue;
 
-                const option_points = try shape.getNewSdfPoint(allocator);
+                const option_points = try shape.getRelativePoints(allocator);
                 if (option_points) |points| {
                     const bounds = shape.getBoundsWithPadding(
                         1 / shared.render_scale,
                         false,
                     );
-                    shape.sdf_size = texture_size.get_sdf_size(bounds);
+                    const desired_size = texture_size.get_allowed_size(
+                        bounds[0].distance(bounds[1]),
+                        bounds[0].distance(bounds[3]),
+                    );
+                    shape.sdf_size = texture_size.get_allowed_sdf_size(desired_size);
 
-                    const init_width = bounds[0].distance(bounds[1]) * shared.render_scale;
+                    const init_width = bounds[0].distance(bounds[1]) * shared.render_scale; // this multiplication is weird
                     // * shared.render_scale to revert to logical scale, without impact of camera/zoom
 
                     shape.sdf_scale = shape.sdf_size.w / init_width;
@@ -832,8 +841,8 @@ pub fn calculateShapesSDF() !void {
                     if (shape.sdf_size.w > consts.MIN_TEXTURE_SIZE and shape.sdf_size.h > consts.MIN_TEXTURE_SIZE) {
                         web_gpu_programs.compute_shape(
                             points,
-                            @floor(shape.sdf_size.w),
-                            @floor(shape.sdf_size.h),
+                            @intFromFloat(shape.sdf_size.w),
+                            @intFromFloat(shape.sdf_size.h),
                             shape.sdf_texture_id,
                         );
 
@@ -857,38 +866,43 @@ pub fn calculateShapesSDF() !void {
             if (d.sdf_texture_id) |sdf_texture_id| {
                 if (!d.outdated_sdf) continue;
 
-                const w = 100.0 * d.width;
-                const h = 100.0 * d.height;
+                const logical_w = d.max_requested_font_size * d.width + 2 * d.max_requested_effect_padding;
+                const logical_h = d.max_requested_font_size * d.height + 2 * d.max_requested_effect_padding;
+                const viewport_desired_size = texture_size.TextureSize{
+                    .w = logical_w, // / shared.render_scale,
+                    .h = logical_h, // / shared.render_scale,
+                };
 
-                // const bounds = [4]types.PointUV{
-                //     .{ .x = 0.0, .y = 0.0, .u = 0.0, .v = 0.0 },
-                //     .{ .x = w, .y = 0.0, .u = 1.0, .v = 0.0 },
-                //     .{ .x = w, .y = h, .u = 1.0, .v = 1.0 },
-                //     .{ .x = 0.0, .y = h, .u = 0.0, .v = 1.0 },
-                // };
-                // const sdf_size = texture_size.get_sdf_size(bounds);
+                const sdf_size = texture_size.get_allowed_sdf_size(
+                    texture_size.get_allowed_size(viewport_desired_size.w, viewport_desired_size.h),
+                );
+                const width_sdf_size = @ceil(sdf_size.w); // ceil because without it, while casting f32 to u32 it rounds down
+                // and often the end of the texture cuts out large part of the padding and in the result shapes touched the edge
+                const height_sdf_size = @ceil(sdf_size.h);
 
-                // const init_width = bounds[0].distance(bounds[1]) * shared.render_scale;
-                // * shared.render_scale to revert to logical scale, without impact of camera/zoom
+                const sdf_scale = width_sdf_size / viewport_desired_size.w;
 
-                // shape.sdf_scale = shape.sdf_size.w / init_width;
-                const ps = try std.heap.page_allocator.dupe(types.Point, d.points);
-                for (ps) |*point| {
-                    point.x = point.x * 100.0;
-                    point.y = point.y * 100.0;
+                // d.paths_container_width = d.max_requested_font_size * d.width * sdf_scale;
+                // d.paths_container_height = d.max_requested_font_size * d.height * sdf_scale;
+                // d.effect_padding = d.max_requested_effect_padding
+
+                const points = try std.heap.page_allocator.dupe(types.Point, d.points);
+                for (points) |*point| {
+                    const x = (point.x * d.max_requested_font_size) + d.max_requested_effect_padding;
+                    const y = (point.y * d.max_requested_font_size) + d.max_requested_effect_padding;
+                    point.x = x * sdf_scale;
+                    point.y = y * sdf_scale;
                 }
 
-                // if (shape.sdf_size.w > consts.MIN_TEXTURE_SIZE and shape.sdf_size.h > consts.MIN_TEXTURE_SIZE) {
                 web_gpu_programs.compute_shape(
-                    ps,
-                    @floor(w),
-                    @floor(h),
+                    points,
+                    @intFromFloat(width_sdf_size),
+                    @intFromFloat(height_sdf_size),
                     sdf_texture_id,
                 );
 
                 d.outdated_sdf = false;
             }
-            // }
         }
     }
 }
@@ -1035,44 +1049,51 @@ pub fn renderDraw() !void {
                     std.ArrayList(triangles.DrawInstance).init(allocator);
                 const matrix = Matrix3x3.getMatrixFromRectangleNoScale(text.bounds);
 
+                const uniform = sdf.DrawUniform{
+                    .solid = .{
+                        .dist_start = 2,
+                        .dist_end = -2,
+                        .color = .{ 0.9, 0.9, 0, 1 },
+                    },
+                };
+
                 for (text.text_vertex.items, 0..) |vertex, i| {
-                    if (vertex.sdf_texture_id) |sdf_texture_id| {
-                        const uniform = sdf.DrawUniform{
-                            .solid = .{
-                                .dist_start = std.math.inf(f32),
-                                .dist_end = 0,
-                                .color = .{ 0.9, 0.9, 0, 1 },
-                            },
-                        };
-
-                        var absolute_vertex: [6]types.PointUV = undefined;
-                        for (vertex.relative_bounds, 0..) |point, j| {
-                            absolute_vertex[j] = matrix.getUV(point);
-                        }
-
-                        web_gpu_programs.draw_shape(
-                            &absolute_vertex,
-                            uniform,
-                            sdf_texture_id,
+                    if (vertex.char) |char| {
+                        const char_details = try fonts.get(
+                            0,
+                            char,
+                            text.font_size,
+                            sdf.getSdfPadding(text.sdf_effects.items),
                         );
-                    }
 
-                    if (is_typing_ui) {
-                        const is_selection = selection_start != selection_end;
+                        if (char_details.sdf_texture_id) |sdf_texture_id| {
+                            const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
+                            const scale_size_to_padding = char_details.max_requested_effect_padding / (char_details.max_requested_font_size * char_details.width);
 
-                        if (!is_selection and texts.caret_position == i) {
-                            const caret_buffer = text.addCaretDrawVertex(
-                                vertex.relative_bounds[0].toPoint(),
+                            web_gpu_programs.draw_shape(
+                                &vertex.getBounds(width * scale_size_to_padding, matrix),
+                                uniform,
+                                sdf_texture_id,
                             );
-                            if (caret_buffer) |buffer| {
-                                try vertex_triangles_buffer.appendSlice(&buffer);
-                            }
                         }
 
-                        if (is_selection and i >= selection_start and i < selection_end) {
-                            try vertex_triangles_buffer.appendSlice(
-                                &text.addTextSelectionDrawVertex(vertex),
-                            );
+                        if (is_typing_ui) {
+                            const is_selection = selection_start != selection_end;
+
+                            if (!is_selection and texts.caret_position == i) {
+                                const caret_buffer = text.addCaretDrawVertex(
+                                    vertex.relative_bounds[3].toPoint(),
+                                );
+                                if (caret_buffer) |buffer| {
+                                    try vertex_triangles_buffer.appendSlice(&buffer);
+                                }
+                            }
+
+                            if (is_selection and i >= selection_start and i < selection_end) {
+                                try vertex_triangles_buffer.appendSlice(
+                                    &text.addTextSelectionDrawVertex(vertex),
+                                );
+                            }
                         }
                     }
                 }
@@ -1081,7 +1102,7 @@ pub fn renderDraw() !void {
                 if (texts.caret_position == text.text_vertex.items.len) {
                     const position =
                         if (text.text_vertex.getLastOrNull()) |last_vertex|
-                            last_vertex.relative_bounds[4].toPoint()
+                            last_vertex.relative_bounds[2].toPoint()
                         else
                             types.Point{
                                 .x = 0,
@@ -1224,7 +1245,7 @@ pub fn renderPick() !void {
 
                 var next_char_is_first_in_line = true;
                 for (text.text_vertex.items, 0..) |vertex, index| {
-                    const half_width = (vertex.relative_bounds[2].x - vertex.origin.x) / 2;
+                    const half_width = (vertex.relative_bounds[1].x - vertex.origin.x) / 2;
                     if (half_width > consts.EPSILON) {
                         const valid_pick_index = index + 1; // pick = 0 -> no selection
                         // left part of the char

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -279,7 +279,7 @@ fn addText(
         bounds,
         font_size,
         props,
-        create_sdf_texture(),
+        null,
     );
     try state.assets.put(id, Asset{ .text = text });
     try checkAssetsUpdate(true);
@@ -448,16 +448,16 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                         .dist_end = 0,
                         .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
                     },
-                    shapes.SerializedSdfEffect{
-                        .dist_start = 3,
-                        .dist_end = 1.5,
-                        .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
-                    },
-                    shapes.SerializedSdfEffect{
-                        .dist_start = -6,
-                        .dist_end = -8,
-                        .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
-                    },
+                    // shapes.SerializedSdfEffect{
+                    //     .dist_start = 3,
+                    //     .dist_end = 1.5,
+                    //     .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+                    // },
+                    // shapes.SerializedSdfEffect{
+                    //     .dist_start = -6,
+                    //     .dist_end = -8,
+                    //     .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+                    // },
                 },
                 .filter = null,
                 .opacity = 1.0,
@@ -1182,12 +1182,12 @@ pub fn renderDraw() !void {
             },
             .text => |*text| {
                 if (text.sdf_texture_id) |sdf_texture_id| {
-                    const sdf_padding = sdf.getSdfPadding(text.props.sdf_effects.items);
+                    const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
                     for (text.props.sdf_effects.items) |effect| {
                         web_gpu_programs.draw_shape(
                             &sdf.getDrawBounds(
                                 text.bounds,
-                                sdf_padding,
+                                padding,
                                 null,
                             ),
                             text.getDrawUniform(effect, text.sdf_scale),
@@ -1518,6 +1518,17 @@ var ticks: u32 = 0; // it's like a time, but always increases by 1, used for per
 pub fn tick(now: f32) void {
     ticks +%= 1;
     shared.setTime(now);
+}
+
+pub fn toggleSharedTextEffects() void {
+    if (getSelectedText()) |text| {
+        if (text.sdf_texture_id != null) {
+            text.sdf_texture_id = null;
+        } else {
+            text.sdf_texture_id = create_sdf_texture();
+            text.is_sdf_outdated = true;
+        }
+    }
 }
 
 test "reset_assets does not call the real update callback" {

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -448,16 +448,16 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                         .dist_end = 0,
                         .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
                     },
-                    // shapes.SerializedSdfEffect{
-                    //     .dist_start = 6,
-                    //     .dist_end = 4,
-                    //     .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
-                    // },
-                    // shapes.SerializedSdfEffect{
-                    //     .dist_start = -6,
-                    //     .dist_end = -8,
-                    //     .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
-                    // },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = 3,
+                        .dist_end = 1.5,
+                        .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+                    },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = -6,
+                        .dist_end = -8,
+                        .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+                    },
                 },
                 .filter = null,
                 .opacity = 1.0,
@@ -468,7 +468,7 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                 "A",
                 // "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 bounds,
-                2000.0,
+                72.0,
                 props,
             );
             try updateSelectedAsset(AssetId{ ._prim = id });
@@ -899,7 +899,7 @@ pub fn computeSdfs() !void {
                 const padding = ch_d.max_font_size * ch_d.max_ratio_padding_to_font_size;
                 const sdf_dims = sdf.getSdfTextureDims(bounds, padding);
 
-                // ch_d.sdf_scale = sdf_dims.scale;
+                ch_d.sdf_scale = sdf_dims.scale;
 
                 // this is NOT viewport, it's SDF scale, if it's smaller htan requested viewport(often while using zoom)
                 // we will keep regenerating it for no reason!
@@ -973,10 +973,10 @@ pub fn computeSdfs() !void {
             .text => |*text| {
                 if (!text.is_sdf_outdated) continue;
 
-                const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
+                const text_padding = sdf.getSdfPadding(text.props.sdf_effects.items);
                 const sdf_dims = sdf.getSdfTextureDims(
                     text.bounds,
-                    padding,
+                    text_padding,
                 );
                 text.sdf_scale = sdf_dims.scale;
 
@@ -1004,16 +1004,17 @@ pub fn computeSdfs() !void {
 
                             if (ch_d.sdf_texture_id) |char_sdf_texture_id| {
                                 const char_padding = text.font_size * ch_d.max_ratio_padding_to_font_size;
+
                                 const start_x = vertex.relative_bounds[3].x - char_padding;
                                 const start_y = text_viewport_height + vertex.relative_bounds[3].y - char_padding;
                                 const end_x = vertex.relative_bounds[1].x + char_padding;
                                 const end_y = text_viewport_height + vertex.relative_bounds[1].y + char_padding;
 
                                 const placement = Placement{
-                                    .x = start_x * text.sdf_scale,
-                                    .y = start_y * text.sdf_scale,
-                                    .width = (end_x - start_x) * text.sdf_scale,
-                                    .height = (end_y - start_y) * text.sdf_scale,
+                                    .x = (text_padding + start_x) * text.sdf_scale,
+                                    .y = (text_padding + start_y) * text.sdf_scale,
+                                    .width = (text_padding + end_x - start_x) * text.sdf_scale,
+                                    .height = (text_padding + end_y - start_y) * text.sdf_scale,
                                 };
 
                                 web_gpu_programs.combine_sdf(
@@ -1189,7 +1190,7 @@ pub fn renderDraw() !void {
                                 sdf_padding,
                                 null,
                             ),
-                            text.getDrawUniform(effect, 1),
+                            text.getDrawUniform(effect, text.sdf_scale),
                             sdf_texture_id,
                         );
                     }
@@ -1213,11 +1214,8 @@ pub fn renderDraw() !void {
                         // );
                         if (ch_d.sdf_texture_id) |sdf_texture_id| {
                             for (text.props.sdf_effects.items) |effect| {
-                                // const scale_size_to_padding = ch_d.max_requested_viewport_effect_padding / (char_details.max_requested_viewport_font_size * char_details.width);
-                                // const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
-                                const viewport_font_size = text.font_size / shared.render_scale;
                                 web_gpu_programs.draw_shape(
-                                    &vertex.getBounds(viewport_font_size * ch_d.max_ratio_padding_to_font_size, matrix),
+                                    &vertex.getBounds(text.font_size * ch_d.max_ratio_padding_to_font_size, matrix),
                                     text.getDrawUniform(effect, ch_d.sdf_scale),
                                     sdf_texture_id,
                                 );

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -448,16 +448,21 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                         .dist_end = 0,
                         .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
                     },
-                    // shapes.SerializedSdfEffect{
-                    //     .dist_start = 3,
-                    //     .dist_end = 1.5,
-                    //     .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
-                    // },
-                    // shapes.SerializedSdfEffect{
-                    //     .dist_start = -6,
-                    //     .dist_end = -8,
-                    //     .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
-                    // },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = 3,
+                        .dist_end = 1.5,
+                        .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+                    },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = -6,
+                        .dist_end = -8,
+                        .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+                    },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = -12,
+                        .dist_end = -18,
+                        .fill = .{ .solid = .{ 1.0, 1.0, 0.0, 1.0 } },
+                    },
                 },
                 .filter = null,
                 .opacity = 1.0,
@@ -465,10 +470,10 @@ pub fn onPointerDown(x: f32, y: f32) !void {
 
             const new_text = try addText(
                 id,
-                "A",
+                "Hello",
                 // "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 bounds,
-                72.0,
+                72,
                 props,
             );
             try updateSelectedAsset(AssetId{ ._prim = id });
@@ -981,10 +986,7 @@ pub fn computeSdfs() !void {
                 text.sdf_scale = sdf_dims.scale;
 
                 if (text.sdf_texture_id) |text_sdf_texture_id| {
-                    const safe_margin_bottom = 0; //text.font_size * text.line_height; // some ltters like "g" got tail wich excees bottom part outside of bounds
-                    _ = safe_margin_bottom; // autofix
-                    // we have to include this part in final SDF
-                    const text_viewport_height = text.bounds[0].distance(text.bounds[3]);
+                    const bounds_height = text.bounds[0].distance(text.bounds[3]);
 
                     const compute_depth_texture_id = create_compute_depth_texture(
                         @intFromFloat(sdf_dims.size.w),
@@ -1006,9 +1008,9 @@ pub fn computeSdfs() !void {
                                 const char_padding = text.font_size * ch_d.max_ratio_padding_to_font_size;
 
                                 const start_x = vertex.relative_bounds[3].x - char_padding;
-                                const start_y = text_viewport_height + vertex.relative_bounds[3].y - char_padding;
+                                const start_y = bounds_height + vertex.relative_bounds[3].y - char_padding;
                                 const end_x = vertex.relative_bounds[1].x + char_padding;
-                                const end_y = text_viewport_height + vertex.relative_bounds[1].y + char_padding;
+                                const end_y = bounds_height + vertex.relative_bounds[1].y + char_padding;
 
                                 const placement = Placement{
                                     .x = (text_padding + start_x) * text.sdf_scale,
@@ -1184,12 +1186,13 @@ pub fn renderDraw() !void {
                 if (text.sdf_texture_id) |sdf_texture_id| {
                     const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
                     for (text.props.sdf_effects.items) |effect| {
+                        const text_bounds = sdf.getDrawBounds(
+                            text.bounds,
+                            padding,
+                            null,
+                        );
                         web_gpu_programs.draw_shape(
-                            &sdf.getDrawBounds(
-                                text.bounds,
-                                padding,
-                                null,
-                            ),
+                            &text_bounds,
                             text.getDrawUniform(effect, text.sdf_scale),
                             sdf_texture_id,
                         );
@@ -1208,14 +1211,11 @@ pub fn renderDraw() !void {
                     if (vertex.char) |char| {
                         const ch_d = try fonts.get(0, char);
 
-                        // char_details.request_size(
-                        //     text.font_size,
-                        //     sdf.getSdfPadding(text.props.sdf_effects.items),
-                        // );
                         if (ch_d.sdf_texture_id) |sdf_texture_id| {
                             for (text.props.sdf_effects.items) |effect| {
+                                const bounds = vertex.getBounds(text.font_size * ch_d.max_ratio_padding_to_font_size, matrix);
                                 web_gpu_programs.draw_shape(
-                                    &vertex.getBounds(text.font_size * ch_d.max_ratio_padding_to_font_size, matrix),
+                                    &bounds,
                                     text.getDrawUniform(effect, ch_d.sdf_scale),
                                     sdf_texture_id,
                                 );

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -30,6 +30,8 @@ const WebGpuPrograms = struct {
     draw_texture: *const fn ([]const types.PointUV, u32) void,
     draw_triangle: *const fn ([]const triangles.DrawInstance) void,
     compute_shape: *const fn ([]const types.Point, u32, u32, u32) void,
+    clear_sdf: *const fn (u32, u32, u32, u32) void,
+    combine_sdf: *const fn (u32, u32, u32, []const f32) void,
     draw_blur: *const fn (u32, u32, u32, u32, f32, f32) void,
     draw_shape: *const fn ([]const types.PointUV, sdf.DrawUniform, u32) void,
     pick_texture: *const fn ([]const images.PickVertex, u32) void,
@@ -58,8 +60,13 @@ pub fn connectOnAssetSelectionCallback(cb: *const fn ([4]u32) void) void {
 }
 
 var create_sdf_texture: *const fn () u32 = undefined;
-pub fn connectCreateSdfTexture(cb: *const fn () u32) void {
-    create_sdf_texture = cb;
+var create_compute_depth_texture: *const fn (u32, u32) u32 = undefined;
+pub fn connectCreateSdfTexture(
+    create_sdf: *const fn () u32,
+    create_compute_depth: *const fn (u32, u32) u32,
+) void {
+    create_sdf_texture = create_sdf;
+    create_compute_depth_texture = create_compute_depth;
 }
 
 pub const SerializedCharDetails = fonts.SerializedCharDetails;
@@ -199,12 +206,14 @@ pub fn updateRenderScale(scale: f32) !void {
                     shape.outdated_sdf = true;
                 }
             },
-            .text => {},
+            .text => |*text| {
+                text.is_sdf_outdated = true;
+            },
         }
     }
 
     // We don't update font here because we would need to know what fonts/chars are still in use!
-    // so It's better to update them in renderDraw
+    // so It's better to update them in render draw
 }
 
 var next_asset_id: u32 = ASSET_ID_MIN;
@@ -253,13 +262,17 @@ fn addText(
     content: []const u8,
     bounds: [4]types.PointUV,
     font_size: f32,
+    props: shapes.SerializedProps,
 ) !texts.Text {
     const id = if (id_or_zero == 0) generateId() else id_or_zero;
     const text = try texts.Text.new(
+        std.heap.page_allocator,
         id,
         content,
         bounds,
         font_size,
+        props,
+        create_sdf_texture(),
     );
     try state.assets.put(id, Asset{ .text = text });
     try checkAssetsUpdate(true);
@@ -308,7 +321,7 @@ fn checkAssetsUpdate(should_notify: bool) !void {
             },
             .text => |text| {
                 try new_assets_update.append(AssetSerialized{
-                    .text = text.serialize(),
+                    .text = try text.serialize(std.heap.page_allocator),
                 });
             },
         }
@@ -421,12 +434,35 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                 .{ .x = x, .y = y - 1.0, .u = 0.0, .v = 0.0 },
             };
 
+            const props = shapes.SerializedProps{
+                .sdf_effects = &.{
+                    shapes.SerializedSdfEffect{
+                        .dist_start = std.math.inf(f32),
+                        .dist_end = 0,
+                        .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
+                    },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = 6,
+                        .dist_end = 4,
+                        .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+                    },
+                    shapes.SerializedSdfEffect{
+                        .dist_start = -6,
+                        .dist_end = -8,
+                        .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+                    },
+                },
+                .filter = .{ .gaussianBlur = .{ .x = 30, .y = 30 } },
+                .opacity = 1.0,
+            };
+
             const new_text = try addText(
                 id,
                 "o",
                 // "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 bounds,
                 72.0,
+                props,
             );
             try updateSelectedAsset(AssetId{ ._prim = id });
             break :b new_text;
@@ -802,10 +838,88 @@ fn drawProjectBoundary() void {
     web_gpu_programs.draw_triangle(&buffer);
 }
 
+fn requestCharsSdfs() !void {
+    const is_throttle_event = ticks % 5 == 0;
+    _ = is_throttle_event; // autofix
+    var iterator = state.assets.iterator();
+    while (iterator.next()) |asset| {
+        switch (asset.value_ptr.*) {
+            .img => {},
+            .shape => {},
+            .text => |*text| {
+                if (!text.is_sdf_outdated) continue;
+
+                const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
+
+                for (text.text_vertex.items) |vertex| {
+                    if (vertex.char) |char| {
+                        const ch_d = try fonts.get(0, char);
+
+                        ch_d.request_size(
+                            text.font_size,
+                            padding,
+                        );
+                    }
+                }
+            },
+        }
+    }
+}
+
 pub fn computeSdfs() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
+
+    try requestCharsSdfs();
+
+    var fonts_iter = fonts.fonts.iterator();
+    while (fonts_iter.next()) |font_entry| {
+        var font = font_entry.value_ptr.*;
+        var char_iter = font.chars.iterator();
+        while (char_iter.next()) |details_entry| {
+            var ch_d = details_entry.value_ptr;
+            if (ch_d.sdf_texture_id) |sdf_texture_id| {
+                if (!ch_d.outdated_sdf) continue;
+
+                const ch_w = ch_d.max_font_size * ch_d.width;
+                const ch_h = ch_d.max_font_size * ch_d.height;
+                // std.debug.print("d.max_requested_effect_paddinge: {d}\n", .{d.max_requested_effect_padding});
+
+                const bounds = [4]types.PointUV{
+                    .{ .x = 0, .y = ch_h, .u = 0, .v = 1 },
+                    .{ .x = ch_w, .y = ch_h, .u = 1, .v = 1 },
+                    .{ .x = ch_w, .y = 0, .u = 1, .v = 0 },
+                    .{ .x = 0, .y = 0, .u = 0, .v = 0 },
+                };
+                const sdf_dims = sdf.getSdfTextureDims(
+                    bounds,
+                    ch_d.max_effect_padding,
+                );
+
+                ch_d.sdf_scale = sdf_dims.scale;
+                ch_d.max_requested_viewport_font_size = ch_d.max_font_size * ch_d.sdf_scale;
+                ch_d.max_requested_viewport_effect_padding = ch_d.max_effect_padding * ch_d.sdf_scale;
+
+                const points = try std.heap.page_allocator.dupe(types.Point, ch_d.points);
+                for (points) |*point| {
+                    const x = (point.x * ch_d.max_font_size) + ch_d.max_effect_padding;
+                    const y = (point.y * ch_d.max_font_size) + ch_d.max_effect_padding;
+                    point.x = x * ch_d.sdf_scale;
+                    point.y = y * ch_d.sdf_scale;
+                }
+
+                web_gpu_programs.compute_shape(
+                    points,
+                    @intFromFloat(sdf_dims.size.w),
+                    @intFromFloat(sdf_dims.size.h),
+                    sdf_texture_id,
+                );
+
+                ch_d.outdated_sdf = false;
+            }
+        }
+    }
 
     var iterator = state.assets.iterator();
     while (iterator.next()) |asset| {
@@ -846,55 +960,64 @@ pub fn computeSdfs() !void {
                 shape.outdated_sdf = false;
                 shape.should_update_sdf = false;
             },
-            .text => {},
-        }
-    }
+            .text => |*text| {
+                if (!text.is_sdf_outdated) continue;
 
-    var iter = fonts.fonts.iterator();
-    while (iter.next()) |f| {
-        var font = f.value_ptr.*;
-        var char_iter = font.chars.iterator();
-        while (char_iter.next()) |details| {
-            var d = details.value_ptr;
-            if (d.sdf_texture_id) |sdf_texture_id| {
-                if (!d.outdated_sdf) continue;
+                const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
 
-                const ch_w = d.max_font_size * d.width;
-                const ch_h = d.max_font_size * d.height;
-                // std.debug.print("d.max_requested_effect_paddinge: {d}\n", .{d.max_requested_effect_padding});
-
-                const bounds = [4]types.PointUV{
-                    .{ .x = 0, .y = ch_h, .u = 0, .v = 1 },
-                    .{ .x = ch_w, .y = ch_h, .u = 1, .v = 1 },
-                    .{ .x = ch_w, .y = 0, .u = 1, .v = 0 },
-                    .{ .x = 0, .y = 0, .u = 0, .v = 0 },
-                };
-                const sdf_dims = sdf.getSdfTextureDims(
-                    bounds,
-                    d.max_effect_padding,
+                const safe_margin_bottom = 0; //text.font_size * text.line_height; // some ltters like "g" got tail wich excees bottom part outside of bounds
+                // we have to include this part in final SDF
+                const text_viewport_height = (text.bounds[0].distance(text.bounds[3]) + safe_margin_bottom + 2 * padding) / shared.render_scale;
+                const text_viewport_width = (text.bounds[0].distance(text.bounds[1]) + 2 * padding) / shared.render_scale;
+                const sdf_tex_viewport_width: u32 = @intFromFloat(text_viewport_width);
+                const sdf_tex_viewport_height: u32 = @intFromFloat(text_viewport_height);
+                const compute_depth_texture_id = create_compute_depth_texture(
+                    sdf_tex_viewport_width,
+                    sdf_tex_viewport_height,
                 );
 
-                d.sdf_scale = sdf_dims.scale;
-                d.max_requested_viewport_font_size = d.max_font_size * d.sdf_scale;
-                d.max_requested_viewport_effect_padding = d.max_effect_padding * d.sdf_scale;
+                if (text.sdf_texture_id) |text_sdf_texture_id| {
+                    web_gpu_programs.clear_sdf(
+                        text_sdf_texture_id,
+                        compute_depth_texture_id,
+                        sdf_tex_viewport_width,
+                        sdf_tex_viewport_height,
+                    );
 
-                const points = try std.heap.page_allocator.dupe(types.Point, d.points);
-                for (points) |*point| {
-                    const x = (point.x * d.max_font_size) + d.max_effect_padding;
-                    const y = (point.y * d.max_font_size) + d.max_effect_padding;
-                    point.x = x * d.sdf_scale;
-                    point.y = y * d.sdf_scale;
+                    for (text.text_vertex.items) |vertex| {
+                        if (vertex.char) |char| {
+                            const ch_d = try fonts.get(0, char);
+
+                            if (ch_d.sdf_texture_id) |char_sdf_texture_id| {
+                                const font_size_viewport = text.font_size / shared.render_scale;
+                                const scale_text_font_size_to_sdf_font_size = font_size_viewport / ch_d.max_requested_viewport_font_size;
+                                const char_padding = ch_d.max_requested_viewport_effect_padding * scale_text_font_size_to_sdf_font_size;
+                                // TODO: STOP USING shared.render_scale
+                                // the whole purpose of it is to use it as little AS POSSIBLE!
+                                const uniforms = [4]f32{
+                                    vertex.relative_bounds[3].x / shared.render_scale - char_padding,
+                                    text_viewport_height + vertex.relative_bounds[3].y / shared.render_scale - char_padding,
+                                    vertex.relative_bounds[1].x / shared.render_scale + char_padding,
+                                    text_viewport_height + vertex.relative_bounds[1].y / shared.render_scale + char_padding,
+                                };
+
+                                // std.debug.print("uniforms[0]: {d}\n", .{uniforms[0]});
+                                // std.debug.print("uniforms[1]: {d}\n", .{uniforms[1]});
+                                // std.debug.print("uniforms[2]: {d}\n", .{uniforms[2]});
+                                // std.debug.print("uniforms[3]: {d}\n", .{uniforms[3]});
+                                web_gpu_programs.combine_sdf(
+                                    text_sdf_texture_id,
+                                    char_sdf_texture_id,
+                                    compute_depth_texture_id,
+                                    &uniforms,
+                                );
+                            }
+                        }
+                    }
+
+                    text.is_sdf_outdated = false;
                 }
-
-                web_gpu_programs.compute_shape(
-                    points,
-                    @intFromFloat(sdf_dims.size.w),
-                    @intFromFloat(sdf_dims.size.h),
-                    sdf_texture_id,
-                );
-
-                d.outdated_sdf = false;
-            }
+            },
         }
     }
 }
@@ -1046,6 +1169,22 @@ pub fn renderDraw() !void {
                 }
             },
             .text => |*text| {
+                if (text.sdf_texture_id) |sdf_texture_id| {
+                    const sdf_padding = sdf.getSdfPadding(text.props.sdf_effects.items);
+                    for (text.props.sdf_effects.items) |effect| {
+                        web_gpu_programs.draw_shape(
+                            &sdf.getDrawBounds(
+                                text.bounds,
+                                sdf_padding,
+                                null,
+                            ),
+                            text.getDrawUniform(effect, 1),
+                            sdf_texture_id,
+                        );
+                    }
+                    continue;
+                }
+
                 const is_typing_ui = state.tool == .Text and state.selected_asset_id.getPrim() == text.id;
                 const selection_start = @min(texts.caret_position, texts.selection_end_position);
                 const selection_end = @max(texts.caret_position, texts.selection_end_position);
@@ -1057,33 +1196,21 @@ pub fn renderDraw() !void {
                     if (vertex.char) |char| {
                         const char_details = try fonts.get(0, char);
 
-                        char_details.request_size(
-                            text.font_size,
-                            sdf.getSdfPadding(text.sdf_effects.items),
-                        );
-
-                        // std.debug.print("font_size: {d}, padding: {d}\n", .{
-                        //     text.font_size / shared.render_scale,
-                        //     sdf.getSdfPadding(text.sdf_effects.items) / shared.render_scale,
-                        // });
-                        // std.debug.print("char_details.sdf_scale: {d}\n", .{char_details.sdf_scale});
+                        // char_details.request_size(
+                        //     text.font_size,
+                        //     sdf.getSdfPadding(text.props.sdf_effects.items),
+                        // );
                         if (char_details.sdf_texture_id) |sdf_texture_id| {
-                            const scale_size_to_padding = char_details.max_requested_viewport_effect_padding / (char_details.max_requested_viewport_font_size * char_details.width);
-                            const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
+                            for (text.props.sdf_effects.items) |effect| {
+                                const scale_size_to_padding = char_details.max_requested_viewport_effect_padding / (char_details.max_requested_viewport_font_size * char_details.width);
+                                const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
 
-                            const uniform = sdf.DrawUniform{
-                                .solid = .{
-                                    .dist_start = 2 * char_details.sdf_scale,
-                                    .dist_end = -2 * char_details.sdf_scale,
-                                    .color = .{ 0.9, 0.9, 0, 1 },
-                                },
-                            };
-
-                            web_gpu_programs.draw_shape(
-                                &vertex.getBounds(width * scale_size_to_padding, matrix),
-                                uniform,
-                                sdf_texture_id,
-                            );
+                                web_gpu_programs.draw_shape(
+                                    &vertex.getBounds(width * scale_size_to_padding, matrix),
+                                    text.getDrawUniform(effect, char_details.sdf_scale),
+                                    sdf_texture_id,
+                                );
+                            }
                         }
 
                         if (is_typing_ui) {
@@ -1162,37 +1289,6 @@ pub fn renderDraw() !void {
             web_gpu_programs.draw_triangle(vertex_data);
         }
     }
-
-    // testing:
-
-    // const points = [_]types.Point{
-    //     types.Point{ .x = 100.0, .y = 70.0 }, //
-    //     types.Point{ .x = 300.0, .y = 100.0 }, //
-    //     types.Point{ .x = 300.0, .y = 250.0 }, //
-    //     types.Point{ .x = 100.0, .y = 150.0 }, //
-    // };
-    // const p0_v = Triangle.get_round_corner_vector(0, points, 10.0);
-    // const p1_v = Triangle.get_round_corner_vector(1, points, 20.0);
-    // const p2_v = Triangle.get_round_corner_vector(2, points, 80.0);
-    // const p3_v = Triangle.get_round_corner_vector(3, points, 20.0);
-
-    // const color = [_]u8{ 0, 255, 255, 255 };
-
-    // var shape_vertex_data: [2]Triangle.DrawInstance = undefined;
-
-    // Triangle.get_draw_vertex_data(shape_vertex_data[0..1], p0_v, p1_v, p2_v, color);
-    // Triangle.get_draw_vertex_data(shape_vertex_data[1..2], p0_v, p2_v, p3_v, color);
-
-    // web_gpu_programs.draw_triangle(&shape_vertex_data);
-
-    // const msdf_vertex_data = Msdf.get_draw_vertex_data(
-    //     Msdf.IconId.rotate,
-    //     10.0,
-    //     10.0,
-    //     100.0,
-    //     [_]u8{ 255, 0, 0, 255 },
-    // );
-    // web_gpu_programs.draw_msdf(&msdf_vertex_data, 0);
 }
 
 pub fn renderPick() !void {
@@ -1351,6 +1447,7 @@ pub fn resetAssets(new_assets: []const AssetSerialized, with_snapshot: bool) !vo
                     text.content orelse "",
                     text.bounds,
                     text.font_size,
+                    text.props,
                 );
             },
         }

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -26,12 +26,19 @@ const FillType = enum(u8) {
     RadialGradient,
 };
 
+const Placement = struct {
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+};
+
 const WebGpuPrograms = struct {
     draw_texture: *const fn ([]const types.PointUV, u32) void,
     draw_triangle: *const fn ([]const triangles.DrawInstance) void,
     compute_shape: *const fn ([]const types.Point, u32, u32, u32) void,
     clear_sdf: *const fn (u32, u32, u32, u32) void,
-    combine_sdf: *const fn (u32, u32, u32, []const f32) void,
+    combine_sdf: *const fn (u32, u32, u32, Placement) void,
     draw_blur: *const fn (u32, u32, u32, u32, f32, f32) void,
     draw_shape: *const fn ([]const types.PointUV, sdf.DrawUniform, u32) void,
     pick_texture: *const fn ([]const images.PickVertex, u32) void,
@@ -441,27 +448,27 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                         .dist_end = 0,
                         .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
                     },
-                    shapes.SerializedSdfEffect{
-                        .dist_start = 6,
-                        .dist_end = 4,
-                        .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
-                    },
-                    shapes.SerializedSdfEffect{
-                        .dist_start = -6,
-                        .dist_end = -8,
-                        .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
-                    },
+                    // shapes.SerializedSdfEffect{
+                    //     .dist_start = 6,
+                    //     .dist_end = 4,
+                    //     .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+                    // },
+                    // shapes.SerializedSdfEffect{
+                    //     .dist_start = -6,
+                    //     .dist_end = -8,
+                    //     .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+                    // },
                 },
-                .filter = .{ .gaussianBlur = .{ .x = 30, .y = 30 } },
+                .filter = null,
                 .opacity = 1.0,
             };
 
             const new_text = try addText(
                 id,
-                "o",
+                "A",
                 // "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 bounds,
-                72.0,
+                2000.0,
                 props,
             );
             try updateSelectedAsset(AssetId{ ._prim = id });
@@ -839,8 +846,6 @@ fn drawProjectBoundary() void {
 }
 
 fn requestCharsSdfs() !void {
-    const is_throttle_event = ticks % 5 == 0;
-    _ = is_throttle_event; // autofix
     var iterator = state.assets.iterator();
     while (iterator.next()) |asset| {
         switch (asset.value_ptr.*) {
@@ -850,7 +855,7 @@ fn requestCharsSdfs() !void {
                 if (!text.is_sdf_outdated) continue;
 
                 const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
-
+                // std.debug.print("pppppadddding: {d}-------------\n", .{padding});
                 for (text.text_vertex.items) |vertex| {
                     if (vertex.char) |char| {
                         const ch_d = try fonts.get(0, char);
@@ -884,7 +889,6 @@ pub fn computeSdfs() !void {
 
                 const ch_w = ch_d.max_font_size * ch_d.width;
                 const ch_h = ch_d.max_font_size * ch_d.height;
-                // std.debug.print("d.max_requested_effect_paddinge: {d}\n", .{d.max_requested_effect_padding});
 
                 const bounds = [4]types.PointUV{
                     .{ .x = 0, .y = ch_h, .u = 0, .v = 1 },
@@ -892,21 +896,27 @@ pub fn computeSdfs() !void {
                     .{ .x = ch_w, .y = 0, .u = 1, .v = 0 },
                     .{ .x = 0, .y = 0, .u = 0, .v = 0 },
                 };
-                const sdf_dims = sdf.getSdfTextureDims(
-                    bounds,
-                    ch_d.max_effect_padding,
-                );
+                const padding = ch_d.max_font_size * ch_d.max_ratio_padding_to_font_size;
+                const sdf_dims = sdf.getSdfTextureDims(bounds, padding);
 
-                ch_d.sdf_scale = sdf_dims.scale;
-                ch_d.max_requested_viewport_font_size = ch_d.max_font_size * ch_d.sdf_scale;
-                ch_d.max_requested_viewport_effect_padding = ch_d.max_effect_padding * ch_d.sdf_scale;
+                // ch_d.sdf_scale = sdf_dims.scale;
+
+                // this is NOT viewport, it's SDF scale, if it's smaller htan requested viewport(often while using zoom)
+                // we will keep regenerating it for no reason!
+                ch_d.max_requested_viewport_font_size = ch_d.max_font_size * sdf_dims.scale;
+                const viewport_padding = padding * sdf_dims.scale;
+                // ch_d.max_requested_viewport_effect_padding = ch_d.max_effect_padding * ch_d.sdf_scale;
 
                 const points = try std.heap.page_allocator.dupe(types.Point, ch_d.points);
+                // std.debug.print("char texture size {d}x{d}\n", .{ sdf_dims.size.w, sdf_dims.size.h });
+                // std.debug.print("ch_d.max_effect_padding {d}\n", .{ch_d.max_effect_padding});
                 for (points) |*point| {
-                    const x = (point.x * ch_d.max_font_size) + ch_d.max_effect_padding;
-                    const y = (point.y * ch_d.max_font_size) + ch_d.max_effect_padding;
-                    point.x = x * ch_d.sdf_scale;
-                    point.y = y * ch_d.sdf_scale;
+                    if (PathUtils.isStraightLineHandle(point.*)) {
+                        continue;
+                    }
+                    point.x = (point.x * ch_d.max_requested_viewport_font_size) + viewport_padding;
+                    point.y = (point.y * ch_d.max_requested_viewport_font_size) + viewport_padding;
+                    // std.debug.print("point: {d}, {d}\n", .{ point.x, point.y });
                 }
 
                 web_gpu_programs.compute_shape(
@@ -964,24 +974,28 @@ pub fn computeSdfs() !void {
                 if (!text.is_sdf_outdated) continue;
 
                 const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
-
-                const safe_margin_bottom = 0; //text.font_size * text.line_height; // some ltters like "g" got tail wich excees bottom part outside of bounds
-                // we have to include this part in final SDF
-                const text_viewport_height = (text.bounds[0].distance(text.bounds[3]) + safe_margin_bottom + 2 * padding) / shared.render_scale;
-                const text_viewport_width = (text.bounds[0].distance(text.bounds[1]) + 2 * padding) / shared.render_scale;
-                const sdf_tex_viewport_width: u32 = @intFromFloat(text_viewport_width);
-                const sdf_tex_viewport_height: u32 = @intFromFloat(text_viewport_height);
-                const compute_depth_texture_id = create_compute_depth_texture(
-                    sdf_tex_viewport_width,
-                    sdf_tex_viewport_height,
+                const sdf_dims = sdf.getSdfTextureDims(
+                    text.bounds,
+                    padding,
                 );
+                text.sdf_scale = sdf_dims.scale;
 
                 if (text.sdf_texture_id) |text_sdf_texture_id| {
+                    const safe_margin_bottom = 0; //text.font_size * text.line_height; // some ltters like "g" got tail wich excees bottom part outside of bounds
+                    _ = safe_margin_bottom; // autofix
+                    // we have to include this part in final SDF
+                    const text_viewport_height = text.bounds[0].distance(text.bounds[3]);
+
+                    const compute_depth_texture_id = create_compute_depth_texture(
+                        @intFromFloat(sdf_dims.size.w),
+                        @intFromFloat(sdf_dims.size.h),
+                    );
+
                     web_gpu_programs.clear_sdf(
                         text_sdf_texture_id,
                         compute_depth_texture_id,
-                        sdf_tex_viewport_width,
-                        sdf_tex_viewport_height,
+                        @intFromFloat(sdf_dims.size.w),
+                        @intFromFloat(sdf_dims.size.h),
                     );
 
                     for (text.text_vertex.items) |vertex| {
@@ -989,27 +1003,24 @@ pub fn computeSdfs() !void {
                             const ch_d = try fonts.get(0, char);
 
                             if (ch_d.sdf_texture_id) |char_sdf_texture_id| {
-                                const font_size_viewport = text.font_size / shared.render_scale;
-                                const scale_text_font_size_to_sdf_font_size = font_size_viewport / ch_d.max_requested_viewport_font_size;
-                                const char_padding = ch_d.max_requested_viewport_effect_padding * scale_text_font_size_to_sdf_font_size;
-                                // TODO: STOP USING shared.render_scale
-                                // the whole purpose of it is to use it as little AS POSSIBLE!
-                                const uniforms = [4]f32{
-                                    vertex.relative_bounds[3].x / shared.render_scale - char_padding,
-                                    text_viewport_height + vertex.relative_bounds[3].y / shared.render_scale - char_padding,
-                                    vertex.relative_bounds[1].x / shared.render_scale + char_padding,
-                                    text_viewport_height + vertex.relative_bounds[1].y / shared.render_scale + char_padding,
+                                const char_padding = text.font_size * ch_d.max_ratio_padding_to_font_size;
+                                const start_x = vertex.relative_bounds[3].x - char_padding;
+                                const start_y = text_viewport_height + vertex.relative_bounds[3].y - char_padding;
+                                const end_x = vertex.relative_bounds[1].x + char_padding;
+                                const end_y = text_viewport_height + vertex.relative_bounds[1].y + char_padding;
+
+                                const placement = Placement{
+                                    .x = start_x * text.sdf_scale,
+                                    .y = start_y * text.sdf_scale,
+                                    .width = (end_x - start_x) * text.sdf_scale,
+                                    .height = (end_y - start_y) * text.sdf_scale,
                                 };
 
-                                // std.debug.print("uniforms[0]: {d}\n", .{uniforms[0]});
-                                // std.debug.print("uniforms[1]: {d}\n", .{uniforms[1]});
-                                // std.debug.print("uniforms[2]: {d}\n", .{uniforms[2]});
-                                // std.debug.print("uniforms[3]: {d}\n", .{uniforms[3]});
                                 web_gpu_programs.combine_sdf(
                                     text_sdf_texture_id,
                                     char_sdf_texture_id,
                                     compute_depth_texture_id,
-                                    &uniforms,
+                                    placement,
                                 );
                             }
                         }
@@ -1194,20 +1205,20 @@ pub fn renderDraw() !void {
 
                 for (text.text_vertex.items, 0..) |vertex, i| {
                     if (vertex.char) |char| {
-                        const char_details = try fonts.get(0, char);
+                        const ch_d = try fonts.get(0, char);
 
                         // char_details.request_size(
                         //     text.font_size,
                         //     sdf.getSdfPadding(text.props.sdf_effects.items),
                         // );
-                        if (char_details.sdf_texture_id) |sdf_texture_id| {
+                        if (ch_d.sdf_texture_id) |sdf_texture_id| {
                             for (text.props.sdf_effects.items) |effect| {
-                                const scale_size_to_padding = char_details.max_requested_viewport_effect_padding / (char_details.max_requested_viewport_font_size * char_details.width);
-                                const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
-
+                                // const scale_size_to_padding = ch_d.max_requested_viewport_effect_padding / (char_details.max_requested_viewport_font_size * char_details.width);
+                                // const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
+                                const viewport_font_size = text.font_size / shared.render_scale;
                                 web_gpu_programs.draw_shape(
-                                    &vertex.getBounds(width * scale_size_to_padding, matrix),
-                                    text.getDrawUniform(effect, char_details.sdf_scale),
+                                    &vertex.getBounds(viewport_font_size * ch_d.max_ratio_padding_to_font_size, matrix),
+                                    text.getDrawUniform(effect, ch_d.sdf_scale),
                                     sdf_texture_id,
                                 );
                             }

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -189,20 +189,22 @@ pub fn updateRenderScale(scale: f32) !void {
         switch (asset.value_ptr.*) {
             .img => {},
             .shape => |*shape| {
-                const bounds = shape.getBoundsWithPadding(1 / shared.render_scale, false);
-                const desired_size = texture_size.get_allowed_size(
-                    bounds[0].distance(bounds[1]),
-                    bounds[0].distance(bounds[3]),
+                const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
+                const new_sdf_dims = sdf.getSdfTextureDims(
+                    shape.bounds,
+                    sdf_padding,
                 );
-                const new_size = texture_size.get_allowed_sdf_size(desired_size);
 
-                if (new_size.w > shape.sdf_size.w or new_size.h > shape.sdf_size.h) {
+                if (new_sdf_dims.size.w > shape.sdf_size.w or new_sdf_dims.size.h > shape.sdf_size.h) {
                     shape.outdated_sdf = true;
                 }
             },
             .text => {},
         }
     }
+
+    // We don't update font here because we would need to know what fonts/chars are still in use!
+    // so It's better to update them in renderDraw
 }
 
 var next_asset_id: u32 = ASSET_ID_MIN;
@@ -461,7 +463,7 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                         .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
                     },
                 },
-                .filter = .{ .gaussianBlur = .{ .x = 3, .y = 3 } },
+                .filter = .{ .gaussianBlur = .{ .x = 30, .y = 30 } },
                 .opacity = 1.0,
             };
             const id = try addShape(
@@ -818,36 +820,27 @@ pub fn computeSdfs() !void {
 
                 const option_points = try shape.getRelativePoints(allocator);
                 if (option_points) |points| {
-                    const bounds = shape.getBoundsWithPadding(
-                        1 / shared.render_scale,
-                        false,
+                    const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
+                    const sdf_dims = sdf.getSdfTextureDims(
+                        shape.bounds,
+                        sdf_padding,
                     );
-                    const desired_size = texture_size.get_allowed_size(
-                        bounds[0].distance(bounds[1]),
-                        bounds[0].distance(bounds[3]),
-                    );
-                    shape.sdf_size = texture_size.get_allowed_sdf_size(desired_size);
-
-                    const init_width = bounds[0].distance(bounds[1]) * shared.render_scale; // this multiplication is weird
-                    // * shared.render_scale to revert to logical scale (without impact of camera/zoom)
-
-                    shape.sdf_scale = shape.sdf_size.w / init_width;
+                    shape.sdf_size = sdf_dims.size;
+                    shape.sdf_scale = sdf_dims.scale;
 
                     for (points) |*point| {
                         point.x *= shape.sdf_scale;
                         point.y *= shape.sdf_scale;
                     }
 
-                    if (shape.sdf_size.w > consts.MIN_TEXTURE_SIZE and shape.sdf_size.h > consts.MIN_TEXTURE_SIZE) {
-                        web_gpu_programs.compute_shape(
-                            points,
-                            @intFromFloat(shape.sdf_size.w),
-                            @intFromFloat(shape.sdf_size.h),
-                            shape.sdf_texture_id,
-                        );
+                    web_gpu_programs.compute_shape(
+                        points,
+                        @intFromFloat(shape.sdf_size.w),
+                        @intFromFloat(shape.sdf_size.h),
+                        shape.sdf_texture_id,
+                    );
 
-                        shape.outdated_cache = true;
-                    }
+                    shape.outdated_cache = true;
                 }
 
                 shape.outdated_sdf = false;
@@ -866,38 +859,37 @@ pub fn computeSdfs() !void {
             if (d.sdf_texture_id) |sdf_texture_id| {
                 if (!d.outdated_sdf) continue;
 
-                const logical_w = d.max_requested_font_size * d.width + 2 * d.max_requested_effect_padding;
-                const logical_h = d.max_requested_font_size * d.height + 2 * d.max_requested_effect_padding;
-                const viewport_desired_size = texture_size.TextureSize{
-                    .w = logical_w,
-                    .h = logical_h,
+                const ch_w = d.max_font_size * d.width;
+                const ch_h = d.max_font_size * d.height;
+                // std.debug.print("d.max_requested_effect_paddinge: {d}\n", .{d.max_requested_effect_padding});
+
+                const bounds = [4]types.PointUV{
+                    .{ .x = 0, .y = ch_h, .u = 0, .v = 1 },
+                    .{ .x = ch_w, .y = ch_h, .u = 1, .v = 1 },
+                    .{ .x = ch_w, .y = 0, .u = 1, .v = 0 },
+                    .{ .x = 0, .y = 0, .u = 0, .v = 0 },
                 };
-
-                const sdf_size = texture_size.get_allowed_sdf_size(
-                    texture_size.get_allowed_size(viewport_desired_size.w, viewport_desired_size.h),
+                const sdf_dims = sdf.getSdfTextureDims(
+                    bounds,
+                    d.max_effect_padding,
                 );
-                const width_sdf_size = @ceil(sdf_size.w); // ceil because without it, while casting f32 to u32 it rounds down
-                // and often the end of the texture cuts out large part of the padding and in the result shapes touched the edge
-                const height_sdf_size = @ceil(sdf_size.h);
 
-                const sdf_scale = width_sdf_size / viewport_desired_size.w;
-                d.sdf_scale = width_sdf_size / (viewport_desired_size.w * shared.render_scale);
-                // d.paths_container_width = d.max_requested_font_size * d.width * sdf_scale;
-                // d.paths_container_height = d.max_requested_font_size * d.height * sdf_scale;
-                // d.effect_padding = d.max_requested_effect_padding
+                d.sdf_scale = sdf_dims.scale;
+                d.max_requested_viewport_font_size = d.max_font_size * d.sdf_scale;
+                d.max_requested_viewport_effect_padding = d.max_effect_padding * d.sdf_scale;
 
                 const points = try std.heap.page_allocator.dupe(types.Point, d.points);
                 for (points) |*point| {
-                    const x = (point.x * d.max_requested_font_size) + d.max_requested_effect_padding;
-                    const y = (point.y * d.max_requested_font_size) + d.max_requested_effect_padding;
-                    point.x = x * sdf_scale;
-                    point.y = y * sdf_scale;
+                    const x = (point.x * d.max_font_size) + d.max_effect_padding;
+                    const y = (point.y * d.max_font_size) + d.max_effect_padding;
+                    point.x = x * d.sdf_scale;
+                    point.y = y * d.sdf_scale;
                 }
 
                 web_gpu_programs.compute_shape(
                     points,
-                    @intFromFloat(width_sdf_size),
-                    @intFromFloat(height_sdf_size),
+                    @intFromFloat(sdf_dims.size.w),
+                    @intFromFloat(sdf_dims.size.h),
                     sdf_texture_id,
                 );
 
@@ -922,9 +914,12 @@ pub fn updateCache() void {
                         break :b id;
                     };
 
-                    const bounds = shape.getBoundsWithPadding(
+                    const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
+                    const bounds = sdf.getBoundsWithPadding(
+                        shape.bounds,
+                        sdf_padding,
                         1 / shared.render_scale,
-                        true,
+                        shape.getFilterMargin(),
                     );
                     const init_width = bounds[0].distance(bounds[1]) * shared.render_scale;
                     const size, const sigma, const cache_scale = texture_size.get_safe_blur_dims(
@@ -1026,15 +1021,24 @@ pub fn renderDraw() !void {
                 web_gpu_programs.draw_texture(&vertex_data, img.texture_id);
             },
             .shape => |*shape| {
+                const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
                 if (shape.cache_texture_id) |cache_texture_id| {
                     web_gpu_programs.draw_texture(
-                        &shape.getDrawBounds(true),
+                        &sdf.getDrawBounds(
+                            shape.bounds,
+                            sdf_padding,
+                            shape.getFilterMargin(),
+                        ),
                         cache_texture_id,
                     );
                 } else {
                     for (shape.props.sdf_effects.items) |effect| {
                         web_gpu_programs.draw_shape(
-                            &shape.getDrawBounds(true),
+                            &sdf.getDrawBounds(
+                                shape.bounds,
+                                sdf_padding,
+                                shape.getFilterMargin(),
+                            ),
                             shape.getDrawUniform(effect),
                             shape.sdf_texture_id,
                         );
@@ -1051,19 +1055,20 @@ pub fn renderDraw() !void {
 
                 for (text.text_vertex.items, 0..) |vertex, i| {
                     if (vertex.char) |char| {
-                        const char_details = try fonts.get_with_sdf(
-                            0,
-                            char,
-                            text.font_size / shared.render_scale,
-                            sdf.getSdfPadding(text.sdf_effects.items) / shared.render_scale,
+                        const char_details = try fonts.get(0, char);
+
+                        char_details.request_size(
+                            text.font_size,
+                            sdf.getSdfPadding(text.sdf_effects.items),
                         );
+
                         // std.debug.print("font_size: {d}, padding: {d}\n", .{
                         //     text.font_size / shared.render_scale,
                         //     sdf.getSdfPadding(text.sdf_effects.items) / shared.render_scale,
                         // });
                         // std.debug.print("char_details.sdf_scale: {d}\n", .{char_details.sdf_scale});
                         if (char_details.sdf_texture_id) |sdf_texture_id| {
-                            const scale_size_to_padding = char_details.max_requested_effect_padding / (char_details.max_requested_font_size * char_details.width);
+                            const scale_size_to_padding = char_details.max_requested_viewport_effect_padding / (char_details.max_requested_viewport_font_size * char_details.width);
                             const width = vertex.relative_bounds[1].x - vertex.relative_bounds[0].x;
 
                             const uniform = sdf.DrawUniform{
@@ -1137,8 +1142,13 @@ pub fn renderDraw() !void {
         const hover_point_id = state.hovered_asset_id;
 
         if (getSelectedShape()) |shape| {
+            const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
             web_gpu_programs.draw_shape(
-                &shape.getDrawBounds(false),
+                &sdf.getDrawBounds(
+                    shape.bounds,
+                    sdf_padding,
+                    null,
+                ),
                 shape.getSkeletonUniform(),
                 shape.sdf_texture_id,
             );

--- a/src/logic/sdf/sdf.zig
+++ b/src/logic/sdf/sdf.zig
@@ -198,6 +198,7 @@ pub fn getDrawBounds(bounds: [4]PointUV, sdf_padding: f32, filter_margin: ?Point
 pub fn getSdfTextureDims(bounds: [4]PointUV, sdf_padding: f32) struct {
     size: texture_size.TextureSize,
     scale: f32,
+    // rounding_error: texture_size.TextureSize,
 } {
     const bounds_with_padding = getBoundsWithPadding(
         bounds,
@@ -211,19 +212,23 @@ pub fn getSdfTextureDims(bounds: [4]PointUV, sdf_padding: f32) struct {
         bounds_with_padding[0].distance(bounds_with_padding[3]),
     );
 
-    var sdf_size = texture_size.get_allowed_sdf_size(desired_size);
-    sdf_size.w = @max(sdf_size.w, consts.MIN_TEXTURE_SIZE);
-    sdf_size.h = @max(sdf_size.h, consts.MIN_TEXTURE_SIZE);
-    sdf_size.w = @ceil(sdf_size.w); // ceil because without it, while casting f32 to u32 it rounds down
-    // and often the end of the texture cuts out large part of the padding and in the result shapes touched the edge
-    sdf_size.h = @ceil(sdf_size.h);
+    const sdf_size = texture_size.get_allowed_sdf_size(desired_size);
+    const sdf_safe_size = texture_size.TextureSize{
+        .w = @ceil(@max(sdf_size.w, consts.MIN_TEXTURE_SIZE)),
+        .h = @ceil(@max(sdf_size.h, consts.MIN_TEXTURE_SIZE)), // ceil because without it, while casting f32 to u32 it rounds down
+        // and often the end of the texture cuts out large part of the padding and in the result shapes touched the edge
+    };
 
     const init_width = bounds_with_padding[0].distance(bounds_with_padding[1]) * shared.render_scale; // this multiplication is weird
     // * shared.render_scale to revert to logical scale (without impact of camera/zoom)
     const sdf_scale = sdf_size.w / init_width;
 
     return .{
-        .size = sdf_size,
+        .size = sdf_safe_size,
         .scale = sdf_scale,
+        // .rounding_error = .{
+        //     .w = sdf_safe_size.w - sdf_size.w,
+        //     .h = sdf_safe_size.h - sdf_size.h,
+        // },
     };
 }

--- a/src/logic/sdf/sdf.zig
+++ b/src/logic/sdf/sdf.zig
@@ -1,5 +1,13 @@
 const Point = @import("../types.zig").Point;
 const fill = @import("fill.zig");
+const std = @import("std");
+
+// pub const Padding = struct {
+//     left: f32,
+//     right: f32,
+//     top: f32,
+//     bottom: f32,
+// };
 
 pub const Effect = struct {
     dist_start: f32,
@@ -113,4 +121,22 @@ pub fn getDrawUniform(sdf_effect: Effect, sdf_scale: f32, opacity: f32) DrawUnif
             };
         },
     }
+}
+
+pub fn getSdfPadding(sdf_effects: []Effect) f32 {
+    var padding: f32 = 0.0;
+    // because of skeleton render, we cannot od less than zero
+
+    for (sdf_effects) |effect| {
+        if (std.math.isInf(effect.dist_end)) {
+            std.debug.print("SDF effect dist_end cannot be infinite!\n effect: {any}\n", .{effect});
+            @panic("SDF effect dist_end cannot be infinite!");
+        }
+        padding = @max(padding, -effect.dist_end);
+    }
+
+    // we do smoothing in shaders wit fwidth(), so it's 1px to make sure we wont cut it out
+    padding += 1.0;
+
+    return padding;
 }

--- a/src/logic/sdf/sdf.zig
+++ b/src/logic/sdf/sdf.zig
@@ -1,6 +1,10 @@
 const Point = @import("../types.zig").Point;
+const PointUV = @import("../types.zig").PointUV;
+const texture_size = @import("../texture_size.zig");
 const fill = @import("fill.zig");
 const std = @import("std");
+const shared = @import("../shared.zig");
+const consts = @import("../consts.zig");
 
 // pub const Padding = struct {
 //     left: f32,
@@ -139,4 +143,87 @@ pub fn getSdfPadding(sdf_effects: []Effect) f32 {
     padding += 1.0;
 
     return padding;
+}
+
+pub fn getBoundsWithPadding(bounds: [4]PointUV, sdf_padding: f32, scale: f32, filter_margin: ?Point) [4]PointUV {
+    // const sdf_padding = sdf.getSdfPadding(self.props.sdf_effects.items);
+    var padding = Point{
+        .x = sdf_padding,
+        .y = sdf_padding,
+    };
+
+    if (filter_margin) |margin| {
+        padding.x += margin.x;
+        padding.y += margin.y;
+    }
+
+    var buffer: [4]PointUV = undefined;
+    const bounds_len: usize = 4;
+    for (bounds, 0..) |b, i| {
+        const b_next = bounds[(i + 1) % bounds_len];
+        const b_prev = bounds[@min((i -% 1), (bounds_len - 1)) % bounds_len];
+
+        const angle_next = b.angleTo(b_next);
+        const angle_prev = b.angleTo(b_prev);
+
+        buffer[i] = b;
+        buffer[i].x -= @cos(angle_next) * padding.x + @cos(angle_prev) * padding.x;
+        buffer[i].y -= @sin(angle_next) * padding.y + @sin(angle_prev) * padding.y;
+        buffer[i].x *= scale;
+        buffer[i].y *= scale;
+    }
+
+    return buffer;
+}
+
+pub fn getDrawBounds(bounds: [4]PointUV, sdf_padding: f32, filter_margin: ?Point) [6]PointUV {
+    const bounds_with_padding = getBoundsWithPadding(
+        bounds,
+        sdf_padding,
+        1,
+        filter_margin,
+    );
+    return [_]PointUV{
+        // first triangle
+        bounds_with_padding[0],
+        bounds_with_padding[1],
+        bounds_with_padding[2],
+        // second triangle
+        bounds_with_padding[2],
+        bounds_with_padding[3],
+        bounds_with_padding[0],
+    };
+}
+
+pub fn getSdfTextureDims(bounds: [4]PointUV, sdf_padding: f32) struct {
+    size: texture_size.TextureSize,
+    scale: f32,
+} {
+    const bounds_with_padding = getBoundsWithPadding(
+        bounds,
+        sdf_padding,
+        1 / shared.render_scale,
+        null,
+    );
+
+    const desired_size = texture_size.get_allowed_size(
+        bounds_with_padding[0].distance(bounds_with_padding[1]),
+        bounds_with_padding[0].distance(bounds_with_padding[3]),
+    );
+
+    var sdf_size = texture_size.get_allowed_sdf_size(desired_size);
+    sdf_size.w = @max(sdf_size.w, consts.MIN_TEXTURE_SIZE);
+    sdf_size.h = @max(sdf_size.h, consts.MIN_TEXTURE_SIZE);
+    sdf_size.w = @ceil(sdf_size.w); // ceil because without it, while casting f32 to u32 it rounds down
+    // and often the end of the texture cuts out large part of the padding and in the result shapes touched the edge
+    sdf_size.h = @ceil(sdf_size.h);
+
+    const init_width = bounds_with_padding[0].distance(bounds_with_padding[1]) * shared.render_scale; // this multiplication is weird
+    // * shared.render_scale to revert to logical scale (without impact of camera/zoom)
+    const sdf_scale = sdf_size.w / init_width;
+
+    return .{
+        .size = sdf_size,
+        .scale = sdf_scale,
+    };
 }

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -371,9 +371,9 @@ pub const Shape = struct {
         );
     }
 
-    pub fn getNewSdfPoint(self: *Shape, allocator: std.mem.Allocator) !?[]Point {
+    pub fn getRelativePoints(self: *Shape, allocator: std.mem.Allocator) !?[]Point {
         if (!self.outdated_sdf and !self.should_update_sdf) {
-            @panic("getNewSdfPoint was called but the shape sdf was not marked as outdated!");
+            @panic("getRelativePoints was called but the shape sdf was not marked as outdated!");
         }
         const check_points = try self.getAllPoints(
             allocator,
@@ -401,18 +401,22 @@ pub const Shape = struct {
             self.bounds[0].distance(self.bounds[3]),
         );
 
-        const padding = self.getSdfPadding();
+        const padding = sdf.getSdfPadding(self.props.sdf_effects.items);
         for (points) |*point| {
             const scaled = scale.get(point);
-            point.x = padding.x + scaled.x;
-            point.y = padding.y + scaled.y;
+            point.x = padding + scaled.x;
+            point.y = padding + scaled.y;
         }
 
         return points;
     }
 
     pub fn getBoundsWithPadding(self: Shape, scale: f32, include_filter_margin: bool) [4]PointUV {
-        var padding = self.getSdfPadding();
+        const sdf_padding = sdf.getSdfPadding(self.props.sdf_effects.items);
+        var padding = Point{
+            .x = sdf_padding,
+            .y = sdf_padding,
+        };
 
         if (include_filter_margin) {
             const filter_margin = self.getFilterMargin();
@@ -471,26 +475,6 @@ pub const Shape = struct {
             .x = 3 * filter.gaussianBlur.x,
             .y = 3 * filter.gaussianBlur.y,
         } else consts.POINT_ZERO;
-    }
-
-    fn getSdfPadding(self: Shape) Point {
-        var padding = consts.POINT_ZERO;
-        // because of skeleton render, we cannot od less than zero
-
-        for (self.props.sdf_effects.items) |effect| {
-            if (std.math.isInf(effect.dist_end)) {
-                std.debug.print("SDF effect dist_end cannot be infinite!\nShape ID: {d}, effect: {any}\n", .{ self.id, effect });
-                @panic("SDF effect dist_end cannot be infinite!");
-            }
-            padding.x = @max(padding.x, -effect.dist_end);
-            padding.y = @max(padding.y, -effect.dist_end);
-        }
-
-        // we do smoothing in shaders wit fwidth(), so it's 1px to make sure we wont cut it out
-        padding.x += 1.0;
-        padding.y += 1.0;
-
-        return padding;
     }
 
     pub fn serialize(self: Shape, allocator: std.mem.Allocator) !Serialized {

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -411,55 +411,9 @@ pub const Shape = struct {
         return points;
     }
 
-    pub fn getBoundsWithPadding(self: Shape, scale: f32, include_filter_margin: bool) [4]PointUV {
-        const sdf_padding = sdf.getSdfPadding(self.props.sdf_effects.items);
-        var padding = Point{
-            .x = sdf_padding,
-            .y = sdf_padding,
-        };
-
-        if (include_filter_margin) {
-            const filter_margin = self.getFilterMargin();
-            padding.x += filter_margin.x;
-            padding.y += filter_margin.y;
-        }
-
-        var buffer: [4]PointUV = undefined;
-        const len = self.bounds.len;
-
-        for (self.bounds, 0..) |b, i| {
-            const b_next = self.bounds[(i + 1) % len];
-            const b_prev = self.bounds[@min((i -% 1), (len - 1)) % len];
-
-            const angle_next = b.angleTo(b_next);
-            const angle_prev = b.angleTo(b_prev);
-
-            buffer[i] = b;
-            buffer[i].x -= @cos(angle_next) * padding.x + @cos(angle_prev) * padding.x;
-            buffer[i].y -= @sin(angle_next) * padding.y + @sin(angle_prev) * padding.y;
-            buffer[i].x *= scale;
-            buffer[i].y *= scale;
-        }
-
-        return buffer;
-    }
-
-    pub fn getDrawBounds(self: Shape, include_filter_margin: bool) [6]PointUV {
-        const bounds = self.getBoundsWithPadding(1, include_filter_margin);
-        return [_]PointUV{
-            // first triangle
-            bounds[0],
-            bounds[1],
-            bounds[2],
-            // second triangle
-            bounds[2],
-            bounds[3],
-            bounds[0],
-        };
-    }
-
     pub fn getPickBounds(self: Shape) [6]images.PickVertex {
-        const bounds = self.getDrawBounds(false);
+        const sdf_padding = sdf.getSdfPadding(self.props.sdf_effects.items);
+        const bounds = sdf.getDrawBounds(self.bounds, sdf_padding, null);
         var buffer: [6]images.PickVertex = undefined;
         for (bounds, 0..) |b, i| {
             buffer[i] = .{

--- a/src/logic/texts/chars.zig
+++ b/src/logic/texts/chars.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const Point = @import("../types.zig").Point;
+const shared = @import("../shared.zig");
+const consts = @import("../consts.zig");
 
 pub const Details = struct {
     sdf_texture_id: ?u32,
@@ -7,16 +9,58 @@ pub const Details = struct {
     y: f32,
     width: f32,
     height: f32,
-    max_requested_effect_padding: f32,
-    max_requested_font_size: f32,
+
     points: []const Point,
     outdated_sdf: bool,
     kerning: std.AutoArrayHashMap(u21, f32), // kerning between current char and next one
 
-    paths_container_width: f32 = 0,
-    paths_container_height: f32 = 0,
     effect_padding: f32 = 0,
+
     sdf_scale: f32 = 1,
+
+    // those two are absolute, final, renderable sizes
+    // those values only serve to avoid unnecesary recomputation of SDF
+    max_requested_viewport_effect_padding: f32,
+    max_requested_viewport_font_size: f32,
+
+    // these two are logical sizes, because absolute size depends on render_scale which might
+    // change between requesting and computing SDF, so we use below values
+    // while computing SDF
+    max_font_size: f32 = 1,
+    max_effect_padding: f32 = 1,
+
+    pub fn request_size(self: *Details, font_size: f32, effect_padding: f32) void {
+        const viewport_font_size = font_size / shared.render_scale;
+        const viewport_effect_padding = effect_padding / shared.render_scale;
+
+        if (viewport_font_size > self.max_requested_viewport_font_size or
+            viewport_effect_padding > self.max_requested_viewport_effect_padding)
+        {
+            const bigger_scale_mismatch = @max(
+                font_size / self.max_font_size,
+                effect_padding / self.max_effect_padding,
+            );
+
+            self.max_font_size *= bigger_scale_mismatch;
+            self.max_effect_padding *= bigger_scale_mismatch;
+
+            // once we generate SDF, those values gonna be updated to match actual SDF data
+            // below is just to avoid repeating current code for each char
+            self.max_requested_viewport_font_size = self.max_font_size / shared.render_scale + consts.EPSILON;
+            self.max_requested_viewport_effect_padding = self.max_effect_padding / shared.render_scale + consts.EPSILON;
+
+            self.outdated_sdf = true;
+        }
+    }
+
+    pub fn request_padding(self: *Details, padding: f32) void {
+        if (self.max_requested_effect_padding < padding) {
+            const ratio_size_to_padding = self.max_requested_font_size / self.max_requested_effect_padding;
+            self.max_requested_effect_padding = padding;
+            self.max_requested_font_size = padding * ratio_size_to_padding;
+            self.outdated_sdf = true;
+        }
+    }
 };
 
 pub const Chars = struct {

--- a/src/logic/texts/chars.zig
+++ b/src/logic/texts/chars.zig
@@ -14,21 +14,11 @@ pub const Details = struct {
     outdated_sdf: bool,
     kerning: std.AutoArrayHashMap(u21, f32), // kerning between current char and next one
 
-    // effect_padding: f32 = 0,
-
     sdf_scale: f32 = 1,
 
-    // those two are absolute, final, renderable sizes
-    // those values only serve to avoid unnecesary recomputation of SDF
-    // max_requested_viewport_effect_padding: f32,
     max_requested_viewport_font_size: f32 = 0,
-
-    // these two are logical sizes, because absolute size depends on render_scale which might
-    // change between requesting and computing SDF, so we use below values
-    // while computing SDF
     max_font_size: f32 = 0,
-    // max_effect_padding: f32 = 0,
-    max_ratio_padding_to_font_size: f32 = 0, // instead of size of padding
+    max_ratio_padding_to_font_size: f32 = 0,
 
     pub fn request_size(self: *Details, font_size: f32, effect_padding: f32) void {
         if (self.max_ratio_padding_to_font_size < effect_padding / font_size) {
@@ -38,22 +28,8 @@ pub const Details = struct {
 
         const viewport_font_size = font_size / shared.render_scale;
         if (viewport_font_size > self.max_requested_viewport_font_size) {
-            // self.max_requested_viewport_font_size = viewport_font_size;
+            self.max_requested_viewport_font_size = viewport_font_size;
             self.max_font_size = font_size;
-
-            // const bigger_scale_mismatch = @max(
-            //     font_size / self.max_font_size,
-            //     effect_padding / self.max_effect_padding,
-            // );
-
-            // self.max_font_size *= bigger_scale_mismatch;
-            // self.max_effect_padding *= bigger_scale_mismatch;
-
-            // // once we generate SDF, those values gonna be updated to match actual SDF data
-            // // below is just to avoid repeating current code for each char
-            // self.max_requested_viewport_font_size = self.max_font_size / shared.render_scale + consts.EPSILON;
-            // self.max_requested_viewport_effect_padding = self.max_effect_padding / shared.render_scale + consts.EPSILON;
-
             self.outdated_sdf = true;
         }
     }

--- a/src/logic/texts/chars.zig
+++ b/src/logic/texts/chars.zig
@@ -14,50 +14,46 @@ pub const Details = struct {
     outdated_sdf: bool,
     kerning: std.AutoArrayHashMap(u21, f32), // kerning between current char and next one
 
-    effect_padding: f32 = 0,
+    // effect_padding: f32 = 0,
 
     sdf_scale: f32 = 1,
 
     // those two are absolute, final, renderable sizes
     // those values only serve to avoid unnecesary recomputation of SDF
-    max_requested_viewport_effect_padding: f32,
-    max_requested_viewport_font_size: f32,
+    // max_requested_viewport_effect_padding: f32,
+    max_requested_viewport_font_size: f32 = 0,
 
     // these two are logical sizes, because absolute size depends on render_scale which might
     // change between requesting and computing SDF, so we use below values
     // while computing SDF
-    max_font_size: f32 = 1,
-    max_effect_padding: f32 = 1,
+    max_font_size: f32 = 0,
+    // max_effect_padding: f32 = 0,
+    max_ratio_padding_to_font_size: f32 = 0, // instead of size of padding
 
     pub fn request_size(self: *Details, font_size: f32, effect_padding: f32) void {
-        const viewport_font_size = font_size / shared.render_scale;
-        const viewport_effect_padding = effect_padding / shared.render_scale;
-
-        if (viewport_font_size > self.max_requested_viewport_font_size or
-            viewport_effect_padding > self.max_requested_viewport_effect_padding)
-        {
-            const bigger_scale_mismatch = @max(
-                font_size / self.max_font_size,
-                effect_padding / self.max_effect_padding,
-            );
-
-            self.max_font_size *= bigger_scale_mismatch;
-            self.max_effect_padding *= bigger_scale_mismatch;
-
-            // once we generate SDF, those values gonna be updated to match actual SDF data
-            // below is just to avoid repeating current code for each char
-            self.max_requested_viewport_font_size = self.max_font_size / shared.render_scale + consts.EPSILON;
-            self.max_requested_viewport_effect_padding = self.max_effect_padding / shared.render_scale + consts.EPSILON;
-
+        if (self.max_ratio_padding_to_font_size < effect_padding / font_size) {
+            self.max_ratio_padding_to_font_size = effect_padding / font_size;
             self.outdated_sdf = true;
         }
-    }
 
-    pub fn request_padding(self: *Details, padding: f32) void {
-        if (self.max_requested_effect_padding < padding) {
-            const ratio_size_to_padding = self.max_requested_font_size / self.max_requested_effect_padding;
-            self.max_requested_effect_padding = padding;
-            self.max_requested_font_size = padding * ratio_size_to_padding;
+        const viewport_font_size = font_size / shared.render_scale;
+        if (viewport_font_size > self.max_requested_viewport_font_size) {
+            // self.max_requested_viewport_font_size = viewport_font_size;
+            self.max_font_size = font_size;
+
+            // const bigger_scale_mismatch = @max(
+            //     font_size / self.max_font_size,
+            //     effect_padding / self.max_effect_padding,
+            // );
+
+            // self.max_font_size *= bigger_scale_mismatch;
+            // self.max_effect_padding *= bigger_scale_mismatch;
+
+            // // once we generate SDF, those values gonna be updated to match actual SDF data
+            // // below is just to avoid repeating current code for each char
+            // self.max_requested_viewport_font_size = self.max_font_size / shared.render_scale + consts.EPSILON;
+            // self.max_requested_viewport_effect_padding = self.max_effect_padding / shared.render_scale + consts.EPSILON;
+
             self.outdated_sdf = true;
         }
     }

--- a/src/logic/texts/chars.zig
+++ b/src/logic/texts/chars.zig
@@ -16,6 +16,7 @@ pub const Details = struct {
     paths_container_width: f32 = 0,
     paths_container_height: f32 = 0,
     effect_padding: f32 = 0,
+    sdf_scale: f32 = 1,
 };
 
 pub const Chars = struct {

--- a/src/logic/texts/chars.zig
+++ b/src/logic/texts/chars.zig
@@ -7,9 +7,15 @@ pub const Details = struct {
     y: f32,
     width: f32,
     height: f32,
+    max_requested_effect_padding: f32,
+    max_requested_font_size: f32,
     points: []const Point,
     outdated_sdf: bool,
     kerning: std.AutoArrayHashMap(u21, f32), // kerning between current char and next one
+
+    paths_container_width: f32 = 0,
+    paths_container_height: f32 = 0,
+    effect_padding: f32 = 0,
 };
 
 pub const Chars = struct {

--- a/src/logic/texts/fonts.zig
+++ b/src/logic/texts/fonts.zig
@@ -59,8 +59,8 @@ pub fn get(font_id: u32, c: u21) !*chars.Details {
             .points = char.points,
             .outdated_sdf = true,
             .kerning = std.AutoArrayHashMap(u21, f32).init(std.heap.page_allocator),
-            .max_requested_viewport_effect_padding = 50.0, // sdf needs at least 1 texel of empty padding to ensure correct sampling
-            .max_requested_viewport_font_size = 16,
+            .max_requested_viewport_effect_padding = 1, // sdf needs at least 1 texel of empty padding to ensure correct sampling
+            .max_requested_viewport_font_size = 1, // anyway but 0 because we calculate scale later by dividing by font size
         };
         try font.set(c, d);
         // Now get the pointer to the stored struct

--- a/src/logic/texts/fonts.zig
+++ b/src/logic/texts/fonts.zig
@@ -28,10 +28,20 @@ pub fn init() void {
     fonts = std.AutoArrayHashMap(u32, chars.Chars).init(std.heap.page_allocator);
 }
 
-pub fn get(font_id: u32, c: u21) !*chars.Details {
-    const f = fonts.getPtr(font_id) orelse @panic("Font ID not found");
-    const details = f.get(c);
+// pass font_size = 0 and effect_padding = 0 if you are not interested in rendering SDFs
+// eg. you just need to obtain kerning value
+pub fn get(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !*chars.Details {
+    const font = fonts.getPtr(font_id) orelse @panic("Font ID not found");
+    const details = font.get(c);
     if (details) |d| {
+        if (d.max_requested_effect_padding < effect_padding) {
+            d.max_requested_effect_padding = effect_padding;
+            d.outdated_sdf = true;
+        }
+        if (d.max_requested_font_size < font_size) {
+            d.max_requested_font_size = font_size;
+            d.outdated_sdf = true;
+        }
         return d;
     } else {
         const char = getCharData(font_id, c);
@@ -44,15 +54,17 @@ pub fn get(font_id: u32, c: u21) !*chars.Details {
             .points = char.points,
             .outdated_sdf = true,
             .kerning = std.AutoArrayHashMap(u21, f32).init(std.heap.page_allocator),
+            .max_requested_effect_padding = @max(50.0, effect_padding), // sdf needs at least 1 texel of empty padding to ensure correct sampling
+            .max_requested_font_size = font_size,
         };
-        try f.set(c, d);
+        try font.set(c, d);
         // Now get the pointer to the stored struct
-        return f.get(c) orelse @panic("Failed to retrieve stored character details");
+        return font.get(c) orelse @panic("Failed to retrieve stored character details");
     }
 }
 
 pub fn get_kerning(font_id: u32, c1: u21, c2: u21) !f32 {
-    var details = try get(font_id, c1);
+    var details = try get(font_id, c1, 0, 0);
     if (details.kerning.get(c2)) |k| {
         return k;
     } else {

--- a/src/logic/texts/fonts.zig
+++ b/src/logic/texts/fonts.zig
@@ -28,20 +28,25 @@ pub fn init() void {
     fonts = std.AutoArrayHashMap(u32, chars.Chars).init(std.heap.page_allocator);
 }
 
-// pass font_size = 0 and effect_padding = 0 if you are not interested in rendering SDFs
-// eg. you just need to obtain kerning value
-pub fn get(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !*chars.Details {
+pub fn get_with_sdf(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !chars.Details {
+    const char_details = try get(font_id, c);
+
+    if (char_details.max_requested_effect_padding < effect_padding) {
+        char_details.max_requested_effect_padding = effect_padding;
+        char_details.outdated_sdf = true;
+    }
+    if (char_details.max_requested_font_size < font_size) {
+        char_details.max_requested_font_size = font_size;
+        char_details.outdated_sdf = true;
+    }
+
+    return char_details.*;
+}
+
+pub fn get(font_id: u32, c: u21) !*chars.Details {
     const font = fonts.getPtr(font_id) orelse @panic("Font ID not found");
     const details = font.get(c);
     if (details) |d| {
-        if (d.max_requested_effect_padding < effect_padding) {
-            d.max_requested_effect_padding = effect_padding;
-            d.outdated_sdf = true;
-        }
-        if (d.max_requested_font_size < font_size) {
-            d.max_requested_font_size = font_size;
-            d.outdated_sdf = true;
-        }
         return d;
     } else {
         const char = getCharData(font_id, c);
@@ -54,8 +59,8 @@ pub fn get(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !*chars.De
             .points = char.points,
             .outdated_sdf = true,
             .kerning = std.AutoArrayHashMap(u21, f32).init(std.heap.page_allocator),
-            .max_requested_effect_padding = @max(50.0, effect_padding), // sdf needs at least 1 texel of empty padding to ensure correct sampling
-            .max_requested_font_size = font_size,
+            .max_requested_effect_padding = 50.0, // sdf needs at least 1 texel of empty padding to ensure correct sampling
+            .max_requested_font_size = 0,
         };
         try font.set(c, d);
         // Now get the pointer to the stored struct
@@ -64,7 +69,7 @@ pub fn get(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !*chars.De
 }
 
 pub fn get_kerning(font_id: u32, c1: u21, c2: u21) !f32 {
-    var details = try get(font_id, c1, 0, 0);
+    var details = try get(font_id, c1);
     if (details.kerning.get(c2)) |k| {
         return k;
     } else {

--- a/src/logic/texts/fonts.zig
+++ b/src/logic/texts/fonts.zig
@@ -28,21 +28,6 @@ pub fn init() void {
     fonts = std.AutoArrayHashMap(u32, chars.Chars).init(std.heap.page_allocator);
 }
 
-// pub fn get_with_sdf(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !chars.Details {
-//     const char_details = try get(font_id, c);
-
-//     if (char_details.max_requested_effect_padding < effect_padding) {
-//         char_details.max_requested_effect_padding = effect_padding;
-//         char_details.outdated_sdf = true;
-//     }
-//     if (char_details.max_requested_font_size < font_size) {
-//         char_details.max_requested_font_size = font_size;
-//         char_details.outdated_sdf = true;
-//     }
-
-//     return char_details.*;
-// }
-
 pub fn get(font_id: u32, c: u21) !*chars.Details {
     const font = fonts.getPtr(font_id) orelse @panic("Font ID not found");
     const details = font.get(c);

--- a/src/logic/texts/fonts.zig
+++ b/src/logic/texts/fonts.zig
@@ -28,20 +28,20 @@ pub fn init() void {
     fonts = std.AutoArrayHashMap(u32, chars.Chars).init(std.heap.page_allocator);
 }
 
-pub fn get_with_sdf(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !chars.Details {
-    const char_details = try get(font_id, c);
+// pub fn get_with_sdf(font_id: u32, c: u21, font_size: f32, effect_padding: f32) !chars.Details {
+//     const char_details = try get(font_id, c);
 
-    if (char_details.max_requested_effect_padding < effect_padding) {
-        char_details.max_requested_effect_padding = effect_padding;
-        char_details.outdated_sdf = true;
-    }
-    if (char_details.max_requested_font_size < font_size) {
-        char_details.max_requested_font_size = font_size;
-        char_details.outdated_sdf = true;
-    }
+//     if (char_details.max_requested_effect_padding < effect_padding) {
+//         char_details.max_requested_effect_padding = effect_padding;
+//         char_details.outdated_sdf = true;
+//     }
+//     if (char_details.max_requested_font_size < font_size) {
+//         char_details.max_requested_font_size = font_size;
+//         char_details.outdated_sdf = true;
+//     }
 
-    return char_details.*;
-}
+//     return char_details.*;
+// }
 
 pub fn get(font_id: u32, c: u21) !*chars.Details {
     const font = fonts.getPtr(font_id) orelse @panic("Font ID not found");
@@ -59,8 +59,8 @@ pub fn get(font_id: u32, c: u21) !*chars.Details {
             .points = char.points,
             .outdated_sdf = true,
             .kerning = std.AutoArrayHashMap(u21, f32).init(std.heap.page_allocator),
-            .max_requested_effect_padding = 50.0, // sdf needs at least 1 texel of empty padding to ensure correct sampling
-            .max_requested_font_size = 0,
+            .max_requested_viewport_effect_padding = 50.0, // sdf needs at least 1 texel of empty padding to ensure correct sampling
+            .max_requested_viewport_font_size = 16,
         };
         try font.set(c, d);
         // Now get the pointer to the stored struct

--- a/src/logic/texts/fonts.zig
+++ b/src/logic/texts/fonts.zig
@@ -59,8 +59,6 @@ pub fn get(font_id: u32, c: u21) !*chars.Details {
             .points = char.points,
             .outdated_sdf = true,
             .kerning = std.AutoArrayHashMap(u21, f32).init(std.heap.page_allocator),
-            .max_requested_viewport_effect_padding = 1, // sdf needs at least 1 texel of empty padding to ensure correct sampling
-            .max_requested_viewport_font_size = 1, // anyway but 0 because we calculate scale later by dividing by font size
         };
         try font.set(c, d);
         // Now get the pointer to the stored struct

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -11,6 +11,8 @@ const shared = @import("../shared.zig");
 const lines = @import("../lines.zig");
 const Matrix3x3 = @import("../matrix.zig").Matrix3x3;
 const sdf = @import("../sdf/sdf.zig");
+const shapes = @import("../shapes/shapes.zig");
+const fill = @import("../sdf/fill.zig");
 
 const ENTER_CHAR_CODE: u21 = 0xa;
 const SOFT_BREAK_MARKER: u21 = 0x2060;
@@ -60,21 +62,42 @@ pub const Text = struct {
     serialized_updated_content: []const u8 = &.{}, // to cache results of computeText
     // useful when user clicks on text again in the future to be used as input for HTMLTextAreaElement
 
-    sdf_effects: std.ArrayList(sdf.Effect),
+    sdf_texture_id: ?u32 = null,
+    is_sdf_outdated: bool = true,
+    props: shapes.Props,
 
     pub fn new(
+        allocator: std.mem.Allocator,
         id: u32,
         content: []const u8,
         bounds: [4]PointUV,
         font_size: f32,
+        input_props: shapes.SerializedProps,
+        sdf_texture_id: ?u32,
     ) !Text {
+        var effects_list = std.ArrayList(sdf.Effect).init(allocator);
+        for (input_props.sdf_effects) |effect| {
+            try effects_list.append(sdf.Effect{
+                .dist_start = effect.dist_start,
+                .dist_end = effect.dist_end,
+                .fill = try fill.Fill.new(effect.fill, allocator),
+            });
+        }
+
+        const props = shapes.Props{
+            .sdf_effects = effects_list,
+            .filter = input_props.filter,
+            .opacity = input_props.opacity,
+        };
+
         var text = Text{
             .id = id,
             .content = content,
             .font_size = font_size,
             .bounds = bounds,
-            .text_vertex = std.ArrayList(CharVertex).init(std.heap.page_allocator),
-            .sdf_effects = std.ArrayList(sdf.Effect).init(std.heap.page_allocator),
+            .text_vertex = std.ArrayList(CharVertex).init(allocator),
+            .props = props,
+            .sdf_texture_id = sdf_texture_id,
         };
 
         _ = try text.computeText(0, 0);
@@ -230,6 +253,8 @@ pub const Text = struct {
         std.heap.page_allocator.free(self.serialized_updated_content); // free previous content
         self.serialized_updated_content = try serialized_updated_content.toOwnedSlice();
 
+        self.is_sdf_outdated = true;
+
         return .{
             .content = self.serialized_updated_content,
             .selection_start = new_selection_start,
@@ -303,12 +328,36 @@ pub const Text = struct {
         return null;
     }
 
-    pub fn serialize(self: Text) Serialized {
+    pub fn getDrawUniform(self: Text, sdf_effect: sdf.Effect, sdf_scale: f32) sdf.DrawUniform {
+        return sdf.getDrawUniform(
+            sdf_effect,
+            sdf_scale,
+            self.props.opacity,
+        );
+    }
+
+    pub fn serialize(self: Text, allocator: std.mem.Allocator) !Serialized {
+        var effects_list = std.ArrayList(shapes.SerializedSdfEffect).init(allocator);
+        for (self.props.sdf_effects.items) |effect| {
+            try effects_list.append(shapes.SerializedSdfEffect{
+                .dist_start = effect.dist_start,
+                .dist_end = effect.dist_end,
+                .fill = effect.fill.serialize(),
+            });
+        }
+
+        const props = shapes.SerializedProps{
+            .sdf_effects = try effects_list.toOwnedSlice(),
+            .filter = self.props.filter,
+            .opacity = self.props.opacity,
+        };
+
         return Serialized{
             .id = self.id,
             .content = self.content,
             .font_size = self.font_size,
             .bounds = self.bounds,
+            .props = props,
         };
     }
 };
@@ -319,4 +368,5 @@ pub const Serialized = struct {
     // to avoid throwing the exception
     bounds: [4]PointUV,
     font_size: f32,
+    props: shapes.SerializedProps,
 };

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -131,12 +131,7 @@ pub const Text = struct {
             if (new_selection_start == 0 and cp_index >= selection_start) new_selection_start = self.text_vertex.items.len;
             if (new_selection_end == 0 and cp_index >= selection_end) new_selection_end = self.text_vertex.items.len;
 
-            const char_details = try fonts.get(
-                0,
-                cp,
-                self.font_size,
-                sdf.getSdfPadding(self.sdf_effects.items),
-            );
+            const char_details = try fonts.get(0, cp);
             const char_width = (char_details.x + char_details.width) * self.font_size;
 
             var space_before = if (option_prev_cp) |prev_cp| b: {

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -10,6 +10,7 @@ const rects = @import("../rects.zig");
 const shared = @import("../shared.zig");
 const lines = @import("../lines.zig");
 const Matrix3x3 = @import("../matrix.zig").Matrix3x3;
+const sdf = @import("../sdf/sdf.zig");
 
 const ENTER_CHAR_CODE: u21 = 0xa;
 const SOFT_BREAK_MARKER: u21 = 0x2060;
@@ -22,10 +23,25 @@ pub var selection_end_position: u32 = 0; // selection start is indicated by care
 pub var last_caret_update: u32 = 0;
 
 pub const CharVertex = struct {
-    relative_bounds: [6]PointUV,
-    sdf_texture_id: ?u32,
+    relative_bounds: [4]PointUV,
+    char: ?u21,
     origin: Point, // origin of the char (bottom left corner), useful for drawing selection/caret/picking
     last_in_line: bool = false,
+
+    pub fn getBounds(self: CharVertex, padding: f32, matrix: Matrix3x3) [6]PointUV {
+        const b = self.relative_bounds;
+        const p = padding;
+        return [_]PointUV{
+            // first triangle
+            matrix.getUV(.{ .x = b[3].x - p, .y = b[3].y - p, .u = 0.0, .v = 0.0 }),
+            matrix.getUV(.{ .x = b[0].x - p, .y = b[0].y + p, .u = 0.0, .v = 1.0 }),
+            matrix.getUV(.{ .x = b[1].x + p, .y = b[1].y + p, .u = 1.0, .v = 1.0 }),
+            // second triangle
+            matrix.getUV(.{ .x = b[1].x + p, .y = b[1].y + p, .u = 1.0, .v = 1.0 }),
+            matrix.getUV(.{ .x = b[2].x + p, .y = b[2].y - p, .u = 1.0, .v = 0.0 }),
+            matrix.getUV(.{ .x = b[3].x - p, .y = b[3].y - p, .u = 0.0, .v = 0.0 }),
+        };
+    }
 };
 
 pub const ComputeTextResult = struct {
@@ -44,6 +60,8 @@ pub const Text = struct {
     serialized_updated_content: []const u8 = &.{}, // to cache results of computeText
     // useful when user clicks on text again in the future to be used as input for HTMLTextAreaElement
 
+    sdf_effects: std.ArrayList(sdf.Effect),
+
     pub fn new(
         id: u32,
         content: []const u8,
@@ -56,6 +74,7 @@ pub const Text = struct {
             .font_size = font_size,
             .bounds = bounds,
             .text_vertex = std.ArrayList(CharVertex).init(std.heap.page_allocator),
+            .sdf_effects = std.ArrayList(sdf.Effect).init(std.heap.page_allocator),
         };
 
         _ = try text.computeText(0, 0);
@@ -63,7 +82,7 @@ pub const Text = struct {
         return text;
     }
 
-    fn getDrawRelativeBounds(self: Text, x: f32, y: f32, width: f32, height: f32, origin: Point) [6]PointUV {
+    fn getDrawRelativeBounds(self: Text, x: f32, y: f32, width: f32, height: f32, origin: Point) [4]PointUV {
         const w = width * self.font_size;
         const h = height * self.font_size;
         const p = Point{
@@ -71,9 +90,7 @@ pub const Text = struct {
             .y = origin.y + y * self.font_size,
         };
         return [_]PointUV{
-            .{ .x = p.x, .y = p.y, .u = 0.0, .v = 0.0 },
             .{ .x = p.x, .y = p.y + h, .u = 0.0, .v = 1.0 },
-            .{ .x = p.x + w, .y = p.y + h, .u = 1.0, .v = 1.0 },
             .{ .x = p.x + w, .y = p.y + h, .u = 1.0, .v = 1.0 },
             .{ .x = p.x + w, .y = p.y, .u = 1.0, .v = 0.0 },
             .{ .x = p.x, .y = p.y, .u = 0.0, .v = 0.0 },
@@ -114,7 +131,12 @@ pub const Text = struct {
             if (new_selection_start == 0 and cp_index >= selection_start) new_selection_start = self.text_vertex.items.len;
             if (new_selection_end == 0 and cp_index >= selection_end) new_selection_end = self.text_vertex.items.len;
 
-            const char_details = try fonts.get(0, cp);
+            const char_details = try fonts.get(
+                0,
+                cp,
+                self.font_size,
+                sdf.getSdfPadding(self.sdf_effects.items),
+            );
             const char_width = (char_details.x + char_details.width) * self.font_size;
 
             var space_before = if (option_prev_cp) |prev_cp| b: {
@@ -132,16 +154,16 @@ pub const Text = struct {
                 try updated_content.append(SOFT_BREAK_MARKER);
                 try self.text_vertex.append(CharVertex{
                     .relative_bounds = self.getDrawRelativeBounds(0, 0, 0, 0, next_pos),
-                    .sdf_texture_id = null,
                     .origin = next_pos,
+                    .char = null,
                 });
 
                 // add word joiner character before line break so that when user copies the text, they get the same line breaks
                 try updated_content.append(ENTER_CHAR_CODE);
                 try self.text_vertex.append(CharVertex{
                     .relative_bounds = self.getDrawRelativeBounds(0, 0, 0, 0, next_pos),
-                    .sdf_texture_id = null,
                     .origin = next_pos,
+                    .char = null,
                 });
 
                 next_pos = Point{ .x = 0, .y = next_pos.y - lh };
@@ -163,7 +185,7 @@ pub const Text = struct {
             try updated_content.append(cp);
             try self.text_vertex.append(CharVertex{
                 .relative_bounds = relative_bounds,
-                .sdf_texture_id = char_details.sdf_texture_id,
+                .char = cp,
                 .origin = next_pos,
                 .last_in_line = cp == ENTER_CHAR_CODE,
             });
@@ -231,7 +253,7 @@ pub const Text = struct {
             matrix,
             ch_vertex.origin.x,
             ch_vertex.origin.y,
-            ch_vertex.relative_bounds[2].x - ch_vertex.origin.x,
+            ch_vertex.relative_bounds[1].x - ch_vertex.origin.x,
             self.font_size * self.line_height,
             0.0,
             .{ 0, 50, 50, 50 },
@@ -275,7 +297,7 @@ pub const Text = struct {
             const char_details = self.text_vertex.items[caret_index - 1];
 
             // calculate if the click happened more on left side of the char, in this case put caret before the char, not after
-            const left_side = @abs(relative_x - char_details.relative_bounds[0].x) < @abs(relative_x - char_details.relative_bounds[2].x);
+            const left_side = @abs(relative_x - char_details.relative_bounds[0].x) < @abs(relative_x - char_details.relative_bounds[1].x);
             if (left_side) {
                 caret_index -= 1;
             }

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -63,6 +63,7 @@ pub const Text = struct {
     // useful when user clicks on text again in the future to be used as input for HTMLTextAreaElement
 
     sdf_texture_id: ?u32 = null,
+    sdf_scale: f32 = 1.0,
     is_sdf_outdated: bool = true,
     props: shapes.Props,
 

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -142,6 +142,7 @@ pub const Text = struct {
         var iter = (try std.unicode.Utf8View.init(self.content)).iterator();
         var cp_index: usize = 0;
         var option_prev_cp: ?u21 = null;
+        var min_y = -lh;
 
         while (iter.nextCodepoint()) |cp| { // code point
             defer cp_index += 1;
@@ -189,6 +190,10 @@ pub const Text = struct {
                 space_before = 0.0; // we start with a new line, so no kerning needed
             }
 
+            if (cp == ENTER_CHAR_CODE) {
+                next_pos = Point{ .x = 0, .y = next_pos.y - lh };
+            }
+
             const relative_bounds = self.getDrawRelativeBounds(
                 char_details.x,
                 char_details.y,
@@ -209,14 +214,9 @@ pub const Text = struct {
                 .last_in_line = cp == ENTER_CHAR_CODE,
             });
 
-            // so enter is located in same line(self.text_vertex already appended),
-            // and makes new character starting from a new line
-            if (cp == ENTER_CHAR_CODE) {
-                next_pos = Point{ .x = 0, .y = next_pos.y - lh };
-            }
-
             next_pos.x += space_before + char_width;
             longest_line = @max(longest_line, next_pos.x);
+            min_y = @min(min_y, relative_bounds[3].y);
         }
 
         if (self.text_vertex.items.len > 0) {
@@ -237,8 +237,8 @@ pub const Text = struct {
         self.bounds = [_]PointUV{
             matrix.getUV(.{ .x = 0, .y = 0, .u = 0.0, .v = 1.0 }),
             matrix.getUV(.{ .x = text_width, .y = 0, .u = 1.0, .v = 1.0 }),
-            matrix.getUV(.{ .x = text_width, .y = next_pos.y, .u = 1.0, .v = 0.0 }),
-            matrix.getUV(.{ .x = 0, .y = next_pos.y, .u = 0.0, .v = 0.0 }),
+            matrix.getUV(.{ .x = text_width, .y = min_y, .u = 1.0, .v = 0.0 }),
+            matrix.getUV(.{ .x = 0, .y = min_y, .u = 0.0, .v = 0.0 }),
         };
 
         var serialized_updated_content = std.ArrayList(u8).init(std.heap.page_allocator);

--- a/src/logic/texture_size.zig
+++ b/src/logic/texture_size.zig
@@ -8,8 +8,9 @@ pub const TextureSize = struct {
     h: f32,
 };
 
-pub fn get_sdf_size(bounds: [4]PointUV) TextureSize {
-    var size = get_size(bounds);
+// buffer size limits the size of rgba32float texture
+pub fn get_allowed_sdf_size(desired_size: TextureSize) TextureSize {
+    var size = desired_size;
     const sdf_texture_size = size.w * size.h * 16;
 
     if (sdf_texture_size > shared.max_buffer_size) {
@@ -22,10 +23,7 @@ pub fn get_sdf_size(bounds: [4]PointUV) TextureSize {
     return size;
 }
 
-pub fn get_size(bounds: [4]PointUV) TextureSize {
-    const width = bounds[0].distance(bounds[1]);
-    const height = bounds[0].distance(bounds[3]);
-
+pub fn get_allowed_size(width: f32, height: f32) TextureSize {
     const scale = shared.texture_max_size / @max(width, height);
     const ratio = @min(1.0, scale); // makes sure we only downscale
     return TextureSize{ .w = width * ratio, .h = height * ratio };
@@ -34,7 +32,10 @@ pub fn get_size(bounds: [4]PointUV) TextureSize {
 const MAX_COST = 90050924; // it's just chosen base on my own preferences
 // returns new safe size, new sigma and cache scale
 pub fn get_safe_blur_dims(init_width: f32, bounds: [4]PointUV, gaussianBlur: Point) struct { TextureSize, Point, f32 } {
-    var size = get_size(bounds);
+    var size = get_allowed_size(
+        bounds[0].distance(bounds[1]),
+        bounds[0].distance(bounds[3]),
+    );
     // * shared.render_scale to revert to logical scale, without impact of camera/zoom
 
     const init_cache_scale = size.w / init_width;

--- a/src/logic/ui.zig
+++ b/src/logic/ui.zig
@@ -43,7 +43,13 @@ pub fn generateUiElementsSdf(compute_shape: *const fn ([]const Point, u32, u32, 
         var shape = entry.value_ptr;
         const option_points = try shape.getRelativePoints(allocator);
         if (option_points) |points| {
-            const bounds = shape.getBoundsWithPadding(1, false);
+            const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
+            const bounds = sdf.getBoundsWithPadding(
+                shape.bounds,
+                sdf_padding,
+                1,
+                null,
+            );
             shape.sdf_size = texture_size.get_allowed_sdf_size(
                 texture_size.get_allowed_size(
                     bounds[0].distance(bounds[1]),

--- a/src/logic/ui.zig
+++ b/src/logic/ui.zig
@@ -33,7 +33,7 @@ pub fn importUiElement(
     try elements.put(id, shape);
 }
 
-pub fn generateUiElementsSdf(compute_shape: *const fn ([]const Point, f32, f32, u32) void) !void {
+pub fn generateUiElementsSdf(compute_shape: *const fn ([]const Point, u32, u32, u32) void) !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -41,14 +41,19 @@ pub fn generateUiElementsSdf(compute_shape: *const fn ([]const Point, f32, f32, 
     var iterator = elements.iterator();
     while (iterator.next()) |entry| {
         var shape = entry.value_ptr;
-        const option_points = try shape.getNewSdfPoint(allocator);
+        const option_points = try shape.getRelativePoints(allocator);
         if (option_points) |points| {
             const bounds = shape.getBoundsWithPadding(1, false);
-            shape.sdf_size = texture_size.get_sdf_size(bounds);
+            shape.sdf_size = texture_size.get_allowed_sdf_size(
+                texture_size.get_allowed_size(
+                    bounds[0].distance(bounds[1]),
+                    bounds[0].distance(bounds[3]),
+                ),
+            );
             compute_shape(
                 points,
-                @floor(shape.sdf_size.w),
-                @floor(shape.sdf_size.h),
+                @intFromFloat(@floor(shape.sdf_size.w)),
+                @intFromFloat(@floor(shape.sdf_size.h)),
                 shape.sdf_texture_id,
             );
         }

--- a/src/run.ts
+++ b/src/run.ts
@@ -70,7 +70,6 @@ export default function runCreator(
     compute_shape: (curves_data, width, height, textureId) => {
       const curvesDataView = curves_data['*'].dataView
       Textures.update(textureId, width, height)
-      // console.log(curves_data, width, height, textureId)
       computeShape(computePass, curvesDataView, Textures.getTexture(textureId))
     },
     clear_sdf: (sdfTextureId, computeDepthTextureId, width, height) => {
@@ -80,14 +79,13 @@ export default function runCreator(
       clearSdf(computePass, Textures.getTexture(sdfTextureId))
       clearComputeDepth(computePass, Textures.getTexture(computeDepthTextureId))
     },
-    combine_sdf: (destinatioTexId, sourceTexId, computeDepthTextureId, uniformData) => {
-      const placementDataView = uniformData['*'].dataView
+    combine_sdf: (destinatioTexId, sourceTexId, computeDepthTextureId, placementData) => {
       combineSdf(
         computePass,
         Textures.getTexture(destinatioTexId),
         Textures.getTexture(sourceTexId),
         Textures.getTexture(computeDepthTextureId),
-        placementDataView
+        placementData.dataView
       )
     },
     draw_blur: (

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,6 +13,9 @@ import {
   drawBlur,
   canvasMatrix,
   destroyGpuObjects,
+  combineSdf,
+  clearSdf,
+  clearComputeDepth,
 } from 'WebGPU/programs/initPrograms'
 import getCanvasMatrix from 'getCanvasMatrix'
 import PickManager from 'WebGPU/pick'
@@ -66,9 +69,26 @@ export default function runCreator(
     },
     compute_shape: (curves_data, width, height, textureId) => {
       const curvesDataView = curves_data['*'].dataView
-      Textures.updateSDF(textureId, width, height)
+      Textures.update(textureId, width, height)
       // console.log(curves_data, width, height, textureId)
       computeShape(computePass, curvesDataView, Textures.getTexture(textureId))
+    },
+    clear_sdf: (sdfTextureId, computeDepthTextureId, width, height) => {
+      Textures.update(sdfTextureId, width, height)
+      Textures.update(computeDepthTextureId, width, height)
+
+      clearSdf(computePass, Textures.getTexture(sdfTextureId))
+      clearComputeDepth(computePass, Textures.getTexture(computeDepthTextureId))
+    },
+    combine_sdf: (destinatioTexId, sourceTexId, computeDepthTextureId, uniformData) => {
+      const placementDataView = uniformData['*'].dataView
+      combineSdf(
+        computePass,
+        Textures.getTexture(destinatioTexId),
+        Textures.getTexture(sourceTexId),
+        Textures.getTexture(computeDepthTextureId),
+        placementDataView
+      )
     },
     draw_blur: (
       textureId,

--- a/src/run.ts
+++ b/src/run.ts
@@ -149,7 +149,7 @@ export default function runCreator(
     })
 
     computePass = encoder.beginComputePass()
-    Logic.calculateShapesSDF()
+    Logic.computeSdfs()
     computePass.end()
 
     Logic.updateCache()

--- a/src/run.ts
+++ b/src/run.ts
@@ -79,10 +79,10 @@ export default function runCreator(
       clearSdf(computePass, Textures.getTexture(sdfTextureId))
       clearComputeDepth(computePass, Textures.getTexture(computeDepthTextureId))
     },
-    combine_sdf: (destinatioTexId, sourceTexId, computeDepthTextureId, placementData) => {
+    combine_sdf: (destinationTexId, sourceTexId, computeDepthTextureId, placementData) => {
       combineSdf(
         computePass,
-        Textures.getTexture(destinatioTexId),
+        Textures.getTexture(destinationTexId),
         Textures.getTexture(sourceTexId),
         Textures.getTexture(computeDepthTextureId),
         placementData.dataView

--- a/src/textures.ts
+++ b/src/textures.ts
@@ -154,6 +154,20 @@ export function createCacheTexture(): number {
   return textureId
 }
 
+export function createComputeDepthTexture(width: number, height: number): number {
+  const textureId = textures.length
+  const label = 'combineSdf - depth texture'
+  const texture: GPUTexture = device.createTexture({
+    label,
+    size: [width, height],
+    format: 'r32float',
+    usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  })
+
+  textures.push({ url: label, texture })
+  return textureId
+}
+
 export function createSDF(): number {
   const textureId = textures.length
   const label = `SDF texture ${textureId}`
@@ -168,7 +182,7 @@ export function createSDF(): number {
   return textureId
 }
 
-export function updateSDF(textureId: number, width: number, height: number): void {
+export function emptySDF(textureId: number, width: number, height: number): void {
   const label = `SDF texture ${textureId}`
   const texture: GPUTexture = device.createTexture({
     label,
@@ -178,6 +192,26 @@ export function updateSDF(textureId: number, width: number, height: number): voi
   })
 
   textures[textureId].texture?.destroy()
+  textures[textureId].texture = texture
+}
+
+export function update(textureId: number, width: number, height: number): void {
+  const existingTex = textures[textureId]?.texture
+
+  if (!existingTex) throw Error('Texture not found with id: ' + textureId)
+
+  if (existingTex.width === width && existingTex.height === height) {
+    return
+  }
+
+  const texture: GPUTexture = device.createTexture({
+    label: existingTex.label,
+    size: [width, height],
+    format: existingTex.format,
+    usage: existingTex.usage,
+  })
+
+  existingTex?.destroy()
   textures[textureId].texture = texture
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Shared text effects” checkbox and toggle to control SDF-based text effects.
  - Per-character SDF workflow with compute-based compose/clear and a dedicated depth texture for improved text effects and scalability.

- **Bug Fixes**
  - More accurate multi-line text bounds and caret positioning.
  - Reduced visual artifacts via refined sampling and shader adjustments.

- **Documentation**
  - Added design note comparing per-character vs per-text SDF approaches and chosen direction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->