### PR TITLE
fix: change textureId to texture_id to follow zig convention, replace 9999…

### DIFF
--- a/integration-tests/tests/assets-snapshot.spec.ts
+++ b/integration-tests/tests/assets-snapshot.spec.ts
@@ -7,7 +7,7 @@ import init from '../init'
 const STATE_AFTER_UPLOAD = [
   {
     id: 1000,
-    textureId: 1,
+    texture_id: 1,
     points: [
       {
         u: 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export type SerializedInputImage = {
   id?: number // not needed while loading project but useful for undo/redo to maintain selection
   bounds?: PointUV[]
   url: string
-  textureId?: number
+  texture_id?: number
 }
 
 export type SerializedInputShape = {
@@ -42,7 +42,7 @@ export type SerializedOutputImage = {
   id: number // not needed while loading project but useful for undo/redo to maintain selection
   bounds: PointUV[]
   url: string
-  textureId: number
+  texture_id: number
 }
 
 export type SerializedOutputShape = {
@@ -186,7 +186,7 @@ export default async function initCreator(
         const img = asset.img
         return {
           id: img.id,
-          textureId: img.texture_id,
+          texture_id: img.texture_id,
           bounds: serializeBounds([...img.bounds]),
           url: Textures.getUrl(img.texture_id),
         }
@@ -298,7 +298,7 @@ export default async function initCreator(
                 img: {
                   id: asset.id || NO_ASSET_ID,
                   bounds: asset.bounds,
-                  texture_id: asset.textureId || Textures.add(asset.url), // if we got points, so we have url on the server for sure
+                  texture_id: asset.texture_id || Textures.add(asset.url), // if we got points, so we have url on the server for sure
                 },
               })
             }

--- a/src/svgToShapes/collectShapesData.ts
+++ b/src/svgToShapes/collectShapesData.ts
@@ -189,7 +189,7 @@ export default function collectShapesData(
 
         if (serializedFill) {
           serializedProps.sdf_effects.push({
-            dist_start: Infinity,
+            dist_start: Number.MAX_SAFE_INTEGER,
             dist_end: 0,
             fill: serializedFill,
           })


### PR DESCRIPTION
… with Number.MAX_SAFE_INTEGER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized image payload field to texture_id (previously textureId) across input/output serialization and asset updates/resets. This is a breaking change for consumers of serialized data.
* **Bug Fixes**
  * Improved gradient fill serialization by replacing Infinity with a safe numeric sentinel to avoid compatibility issues.
* **Tests**
  * Updated snapshots to reflect the texture_id field change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->