### PR TITLE
fix: comparing props, update CreatorTool enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export type SerializedInputShape = {
   props: ShapeProps
   sdf_texture_id?: number
   cache_texture_id?: number | null
-  bounds?: PointUV[]
+  bounds: PointUV[]
 }
 
 export type SerializedInputText = {
@@ -68,9 +68,10 @@ export type SerializedOutputAsset =
   | SerializedOutputText
 
 export enum CreatorTool {
-  None = 0,
-  DrawShape = 1,
-  EditShape = 2,
+  SelectAsset = 0,
+  DrawBezierCurve = 1,
+  SelectNode = 2,
+  Text = 3,
 }
 
 export interface CreatorAPI {
@@ -275,7 +276,7 @@ export default async function initCreator(
                   id: asset.id || NO_ASSET_ID,
                   paths: asset.paths,
                   props: asset.props,
-                  bounds: asset.bounds || null,
+                  bounds: asset.bounds,
                   sdf_texture_id: asset.sdf_texture_id || Textures.createSDF(),
                   cache_texture_id: asset.cache_texture_id || null,
                 },

--- a/src/logic/asset_observer.zig
+++ b/src/logic/asset_observer.zig
@@ -31,11 +31,11 @@ fn notify(option_asset: ?types.Asset) !void {
         switch (asset) {
             .img => |img| notifyWorld(img.bounds, asset_props.SerializedProps{}),
             .shape => |shape| {
-                const props = try asset_props.serializeProps(allocator, shape.props);
+                const props = try shape.props.serialize(allocator);
                 notifyWorld(shape.bounds, props);
             },
             .text => |text| {
-                const props = try asset_props.serializeProps(allocator, text.props);
+                const props = try text.props.serialize(allocator);
                 notifyWorld(text.bounds, props);
             },
         }

--- a/src/logic/asset_props.zig
+++ b/src/logic/asset_props.zig
@@ -43,7 +43,7 @@ pub const SerializedProps = struct {
     opacity: f32 = 1.0,
 
     pub fn compare(self: SerializedProps, other: SerializedProps) bool {
-        if (self.opacity != other.opacity) return false;
+        if (!utils.equalF32(self.opacity, other.opacity)) return false;
 
         if (self.filter) |filter| {
             if (other.filter) |other_filter| {

--- a/src/logic/asset_props.zig
+++ b/src/logic/asset_props.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const sdf = @import("./sdf/sdf.zig");
 const fill = @import("./sdf/fill.zig");
 const types = @import("./types.zig");
+const utils = @import("./utils.zig");
 
 pub const SerializedSdfEffect = struct {
     dist_start: f32,
@@ -17,34 +18,63 @@ pub const Props = struct {
     sdf_effects: std.ArrayList(sdf.Effect),
     filter: ?Filter,
     opacity: f32,
+
+    pub fn serialize(self: Props, allocator: std.mem.Allocator) !SerializedProps {
+        var effects_list = std.ArrayList(SerializedSdfEffect).init(allocator);
+        for (self.sdf_effects.items) |effect| {
+            try effects_list.append(SerializedSdfEffect{
+                .dist_start = effect.dist_start,
+                .dist_end = effect.dist_end,
+                .fill = effect.fill.serialize(),
+            });
+        }
+
+        return SerializedProps{
+            .sdf_effects = try effects_list.toOwnedSlice(),
+            .filter = self.filter,
+            .opacity = self.opacity,
+        };
+    }
 };
 
 pub const SerializedProps = struct {
     sdf_effects: []const SerializedSdfEffect = &.{},
     filter: ?Filter = null,
     opacity: f32 = 1.0,
+
+    pub fn compare(self: SerializedProps, other: SerializedProps) bool {
+        if (self.opacity != other.opacity) return false;
+
+        if (self.filter) |filter| {
+            if (other.filter) |other_filter| {
+                if (!utils.equalBoundPoint(filter.gaussianBlur, other_filter.gaussianBlur)) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } else if (other.filter != null) {
+            return false;
+        }
+
+        if (self.sdf_effects.len != other.sdf_effects.len) return false;
+
+        for (self.sdf_effects, 0..) |effect, i| {
+            const other_effect = other.sdf_effects[i];
+            if (!utils.equalF32(effect.dist_start, other_effect.dist_start)) return false;
+            if (!utils.equalF32(effect.dist_end, other_effect.dist_end)) return false;
+            if (!effect.fill.compare(other_effect.fill)) return false;
+        }
+
+        return true;
+    }
 };
 
-pub fn serializeProps(allocator: std.mem.Allocator, props: Props) !SerializedProps {
-    var effects_list = std.ArrayList(SerializedSdfEffect).init(allocator);
-    for (props.sdf_effects.items) |effect| {
-        try effects_list.append(SerializedSdfEffect{
-            .dist_start = effect.dist_start,
-            .dist_end = effect.dist_end,
-            .fill = effect.fill.serialize(),
-        });
-    }
-
-    return SerializedProps{
-        .sdf_effects = try effects_list.toOwnedSlice(),
-        .filter = props.filter,
-        .opacity = props.opacity,
-    };
-}
-
-pub fn deserializeProps(allocator: std.mem.Allocator, props: SerializedProps) !Props {
+// This function cannot be part of SerializedProps struct because it returns []GradientStop(part of props.fill)
+// and there is no writer interface created(only []u8 can be returned as a slices)
+pub fn deserializeProps(self: SerializedProps, allocator: std.mem.Allocator) !Props {
     var effects_list = std.ArrayList(sdf.Effect).init(allocator);
-    for (props.sdf_effects) |effect| {
+    for (self.sdf_effects) |effect| {
         try effects_list.append(sdf.Effect{
             .dist_start = effect.dist_start,
             .dist_end = effect.dist_end,
@@ -54,7 +84,7 @@ pub fn deserializeProps(allocator: std.mem.Allocator, props: SerializedProps) !P
 
     return Props{
         .sdf_effects = effects_list,
-        .filter = props.filter,
-        .opacity = props.opacity,
+        .filter = self.filter,
+        .opacity = self.opacity,
     };
 }

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -58,14 +58,6 @@ type ImageAsset = {
   texture_id: number
 }
 
-type TextAsset = {
-  id: number
-  content: string | null
-  bounds: PointUV[]
-  font_size: number
-  props: ShapeProps
-}
-
 type ShapeAsset = {
   id: number
   paths: Point[][]
@@ -73,6 +65,14 @@ type ShapeAsset = {
   bounds: PointUV[] | null
   sdf_texture_id: number
   cache_texture_id: number | null
+}
+
+type TextAsset = {
+  id: number
+  content: string | null
+  bounds: PointUV[]
+  font_size: number
+  props: ShapeProps
 }
 
 type ZigAsset = { img: ImageAsset } | { shape: ShapeAsset } | { text: TextAsset }

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -843,7 +843,7 @@ fn requestCharsSdfs() !void {
                 if (!text.is_sdf_outdated) continue;
 
                 const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
-                // std.debug.print("pppppadddding: {d}-------------\n", .{padding});
+
                 for (text.text_vertex.items) |vertex| {
                     if (vertex.char) |char| {
                         const ch_d = try fonts.get(0, char);
@@ -1451,7 +1451,7 @@ pub fn setSelectedAssetProps(ser_props: asset_props.SerializedProps) !void {
                 // img.props = props;
             },
             .shape => |*shape| {
-                shape.props = try asset_props.deserializeProps(std.heap.page_allocator, ser_props);
+                shape.props = try asset_props.deserializeProps(ser_props, std.heap.page_allocator);
                 if (ser_props.filter == null and shape.cache_texture_id != null) {
                     // TODO: https://github.com/mateuszJS/magic-render/issues/204
                     // destroy_texture(shape.cache_texture_id);
@@ -1463,7 +1463,7 @@ pub fn setSelectedAssetProps(ser_props: asset_props.SerializedProps) !void {
                 shape.outdated_sdf = true;
             },
             .text => |*text| {
-                text.props = try asset_props.deserializeProps(std.heap.page_allocator, ser_props);
+                text.props = try asset_props.deserializeProps(ser_props, std.heap.page_allocator);
                 if (text.sdf_texture_id != null) {
                     text.is_sdf_outdated = true;
                 }

--- a/src/logic/sdf/fill.zig
+++ b/src/logic/sdf/fill.zig
@@ -54,6 +54,8 @@ pub const SerializedFill = union(enum) {
                         return false;
                     }
 
+                    if (g.stops.len != other_g.stops.len) return false;
+
                     for (g.stops, 0..) |stop, i| {
                         if (!stop.compare(other_g.stops[i])) return false;
                     }
@@ -70,6 +72,8 @@ pub const SerializedFill = union(enum) {
                     {
                         return false;
                     }
+
+                    if (g.stops.len != other_g.stops.len) return false;
 
                     for (g.stops, 0..) |stop, i| {
                         if (!stop.compare(other_g.stops[i])) return false;

--- a/src/logic/sdf/fill.zig
+++ b/src/logic/sdf/fill.zig
@@ -1,9 +1,20 @@
 const Point = @import("../types.zig").Point;
 const std = @import("std");
+const utils = @import("../utils.zig");
 
 pub const GradientStop = extern struct {
     color: [4]f32,
     offset: f32, // 0..1
+
+    pub fn compare(self: GradientStop, other: GradientStop) bool {
+        if (!utils.equalF32(self.offset, other.offset)) return false;
+
+        for (self.color, 0..) |c, i| {
+            if (!utils.equalF32(c, other.color[i])) return false;
+        }
+
+        return true;
+    }
 };
 
 const SerializedLinearGradient = struct {
@@ -23,6 +34,53 @@ pub const SerializedFill = union(enum) {
     linear: SerializedLinearGradient,
     radial: SerializedRadialGradient,
     solid: [4]f32,
+
+    pub fn compare(self: SerializedFill, other: SerializedFill) bool {
+        return switch (self) {
+            .solid => |color| switch (other) {
+                .solid => |other_color| {
+                    for (color, 0..) |c, i| {
+                        if (!utils.equalF32(c, other_color[i])) return false;
+                    }
+                    return true;
+                },
+                else => false,
+            },
+            .linear => |g| switch (other) {
+                .linear => |other_g| {
+                    if (!utils.equalBoundPoint(g.start, other_g.start) or
+                        !utils.equalBoundPoint(g.end, other_g.end))
+                    {
+                        return false;
+                    }
+
+                    for (g.stops, 0..) |stop, i| {
+                        if (!stop.compare(other_g.stops[i])) return false;
+                    }
+
+                    return true;
+                },
+                else => false,
+            },
+            .radial => |g| switch (other) {
+                .radial => |other_g| {
+                    if (!utils.equalF32(g.radius_ratio, other_g.radius_ratio) or
+                        !utils.equalBoundPoint(g.center, other_g.center) or
+                        !utils.equalBoundPoint(g.destination, other_g.destination))
+                    {
+                        return false;
+                    }
+
+                    for (g.stops, 0..) |stop, i| {
+                        if (!stop.compare(other_g.stops[i])) return false;
+                    }
+
+                    return true;
+                },
+                else => false,
+            },
+        };
+    }
 };
 
 pub const LinearGradient = struct {

--- a/src/logic/sdf/sdf.zig
+++ b/src/logic/sdf/sdf.zig
@@ -132,9 +132,9 @@ pub fn getSdfPadding(sdf_effects: []Effect) f32 {
     // because of skeleton render, we cannot od less than zero
 
     for (sdf_effects) |effect| {
-        if (std.math.isInf(effect.dist_end)) {
-            std.debug.print("SDF effect dist_end cannot be infinite!\n effect: {any}\n", .{effect});
-            @panic("SDF effect dist_end cannot be infinite!");
+        if (effect.dist_end > 9999999) {
+            std.debug.print("SDF effect dist_end should NOT be a large positive number!\n effect: {any}\n", .{effect});
+            @panic("SDF effect dist_end should NOT be a large positive number!");
         }
         padding = @max(padding, -effect.dist_end);
     }

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -86,10 +86,10 @@ pub const Shape = struct {
             try paths_list.append(path);
         }
 
-        const shape = Shape{
+        var shape = Shape{
             .id = id,
             .paths = paths_list,
-            .props = try asset_props.deserializeProps(allocator, input_props),
+            .props = try asset_props.deserializeProps(input_props, allocator),
             .sdf_texture_id = sdf_texture_id,
             .outdated_sdf = true,
             .should_update_sdf = false,
@@ -97,6 +97,14 @@ pub const Shape = struct {
             .cache_texture_id = cache_texture_id,
             .outdated_cache = true,
         };
+
+        // calculate bounds early so there won't be a change detected while serializing
+        // between consts.DEFAULT_BOUNDS  vs real bounds(calculated below)
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const arena_allocator = arena.allocator();
+
+        try shape.update_bounds(arena_allocator, null);
 
         return shape;
     }
@@ -174,7 +182,7 @@ pub const Shape = struct {
         }
     }
 
-    fn update_bounds(self: *Shape, allocator: std.mem.Allocator, option_preview_point: ?Point) !void {
+    pub fn update_bounds(self: *Shape, allocator: std.mem.Allocator, option_preview_point: ?Point) !void {
         const points = try self.getAllPoints(
             allocator,
             option_preview_point,
@@ -406,7 +414,7 @@ pub const Shape = struct {
         return Serialized{
             .id = self.id,
             .paths = try paths_list.toOwnedSlice(),
-            .props = try asset_props.serializeProps(allocator, self.props),
+            .props = try self.props.serialize(allocator),
             .bounds = self.bounds,
             .sdf_texture_id = self.sdf_texture_id,
             .cache_texture_id = self.cache_texture_id,
@@ -451,7 +459,7 @@ pub const Serialized = struct {
         // but how will we handle when a new texture need to be generated??
         const all_match = self.id == other.id and
             self.paths.len == other.paths.len and
-            std.meta.eql(self.props, other.props) and
+            self.props.compare(other.props) and
             utils.compareBounds(self.bounds, other.bounds);
 
         if (!all_match) {

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -80,7 +80,7 @@ pub const Text = struct {
             .font_size = font_size,
             .bounds = bounds,
             .text_vertex = std.ArrayList(CharVertex).init(allocator),
-            .props = try asset_props.deserializeProps(allocator, input_props),
+            .props = try asset_props.deserializeProps(input_props, allocator),
             .sdf_texture_id = sdf_texture_id,
         };
 
@@ -431,6 +431,7 @@ pub const Serialized = struct {
     pub fn compare(self: Serialized, other: Serialized) bool {
         const all_match = self.id == other.id and
             self.font_size == other.font_size and
+            self.props.compare(other.props) and
             utils.compareBounds(self.bounds, other.bounds) and
             std.mem.eql(u8, self.content orelse &.{}, other.content orelse &.{});
 

--- a/src/logic/utils.zig
+++ b/src/logic/utils.zig
@@ -23,7 +23,7 @@ pub fn equalF32(a: f32, b: f32) bool {
 
 // 0.001 tolerance for bounds comparison
 // most of precision issues start at transform_ui module, where we perform lots of trigonometric operations
-pub fn equalBoundPoint(a: PointUV, b: PointUV) bool {
+pub fn equalBoundPoint(a: anytype, b: anytype) bool {
     return @abs(a.x - b.x) < 0.001 and @abs(a.y - b.y) < 0.001;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Updated creation tools: Select Asset, Draw Bezier Curve, Select Node, and Text.
- Bug Fixes
  - Shapes now always include bounds for more accurate initial placement, selection, and hit-testing.
  - Safer rendering padding prevents rare crashes with extreme effect values.
  - Property changes are detected more reliably, reducing unexpected redraws.
  - Applying/removing blur properly manages cache textures, preventing visual artifacts.
- Chores
  - Reduced debug output for a cleaner console/log experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->