### PR TITLE
fix: expose types

### DIFF
--- a/ADRs/type of zig & exported types
+++ b/ADRs/type of zig & exported types
@@ -1,0 +1,5 @@
+The only way to type \*.zig files is to add typescript ambient(without implementation) definition.
+Unfortunately adding export automatically changes this to standard .ts module, and stops providing global typing for
+\*.zig file.
+
+The solution is to use `declare global` block, this one can import(from ./src/types.ts) and export types to make them global(available for zig ambient definition) while we can reexport types from packages from ./src/types.ts

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,14 +1,16 @@
-declare module '*.wgsl' {
-  const content: string
-  export default content
-}
+import type * as types from './src/types'
 
-declare module '*.svg' {
-  const content: string
-  export default content
-}
-
-declare module '*.ttf' {
-  const content: string
-  export default content
+declare global {
+  /* expose types globally to make the available in *.zig ambient declaration.
+  Import & exports in ambient declaration are forbidden.
+  Also these types are needed to be exported from the package.
+  Otherwise if those are needed only internally, we could move them to ./src/logic/index.d.ts */
+  namespace zig {
+    type Point = types.Point
+    type PointUV = types.PointUV
+    type BoundingBox = types.BoundingBox
+    type Id = types.Id
+    type ShapeProps = types.ShapeProps
+    type ZigAsset = types.ZigAsset
+  }
 }

--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -1,4 +1,4 @@
-import initCreator, { SerializedOutputAsset } from '../src/index'
+import initCreator, { Point, SerializedOutputAsset } from '../src/index'
 import { camera } from '../src/pointer'
 
 export interface AssetBasics {

--- a/modules.d.ts
+++ b/modules.d.ts
@@ -1,0 +1,14 @@
+declare module '*.wgsl' {
+  const content: string
+  export default content
+}
+
+declare module '*.svg' {
+  const content: string
+  export default content
+}
+
+declare module '*.ttf' {
+  const content: string
+  export default content
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,6 +2222,7 @@
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"

--- a/src/WebGPU/textureCache.ts
+++ b/src/WebGPU/textureCache.ts
@@ -3,6 +3,7 @@ import mat4 from 'utils/mat4'
 import { updateRenderPass } from 'run'
 import * as Textures from 'textures'
 import getMultisampleTexture from 'getMultisampleTexture'
+import { BoundingBox } from 'types'
 
 let endCacheCallback: VoidFunction = () => {
   throw new Error('Cache not started')

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -4,6 +4,7 @@ import type { Font } from 'opentype.js'
 import parsePathData from 'svgToShapes/parsePathData'
 import * as Textures from 'textures'
 import * as Logic from 'logic/index.zig'
+import { Point } from 'types'
 
 const DEFAULT_SPACE = 250 // expressed in font units
 const ENTER = 10

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,68 +11,16 @@ import generatePreview from 'WebGPU/generatePreview'
 import sanitizeFill from 'sanitizeFill'
 import * as Typing from 'typing'
 import * as Fonts from 'fonts'
-
-export type SerializedInputImage = {
-  id?: number // not needed while loading project but useful for undo/redo to maintain selection
-  bounds?: PointUV[]
-  url: string
-  texture_id?: number
-}
-
-export type SerializedInputShape = {
-  id?: number // not needed while loading project but useful for undo/redo to maintain selection
-  paths: Point[][]
-  props: ShapeProps
-  sdf_texture_id?: number
-  cache_texture_id?: number | null
-  bounds: PointUV[]
-}
-
-export type SerializedInputText = {
-  id?: number // not needed while loading project but useful for undo/redo to maintain selection
-  content: string
-  bounds: PointUV[]
-  font_size: number
-  props: ShapeProps
-}
-
-export type SerializedInputAsset = SerializedInputImage | SerializedInputShape | SerializedInputText
-
-export type SerializedOutputImage = {
-  id: number // not needed while loading project but useful for undo/redo to maintain selection
-  bounds: PointUV[]
-  url: string
-  texture_id: number
-}
-
-export type SerializedOutputShape = {
-  id: number // not needed while loading project but useful for undo/redo to maintain selection
-  paths: Point[][]
-  props: ShapeProps
-  bounds: PointUV[]
-  sdf_texture_id: number
-  cache_texture_id: number | null
-}
-
-export type SerializedOutputText = {
-  id: number // not needed while loading project but useful for undo/redo to maintain selection
-  content: string
-  bounds: PointUV[]
-  font_size: number
-  props: ShapeProps
-}
-
-export type SerializedOutputAsset =
-  | SerializedOutputImage
-  | SerializedOutputShape
-  | SerializedOutputText
-
-export enum CreatorTool {
-  SelectAsset = 0,
-  DrawBezierCurve = 1,
-  SelectNode = 2,
-  Text = 3,
-}
+import {
+  CreatorTool,
+  Id,
+  PointUV,
+  SerializedInputAsset,
+  SerializedOutputAsset,
+  ShapeProps,
+  ZigAsset,
+} from './types'
+export * from './types'
 
 export interface CreatorAPI {
   addImage: (url: string) => void
@@ -226,7 +174,7 @@ export default async function initCreator(
 
   Fonts.loadFont()
 
-  Logic.connectOnAssetSelectionCallback((id) => onAssetSelect([...id]))
+  Logic.connectOnAssetSelectionCallback((id) => onAssetSelect([...id] as Id))
   Logic.connectCreateSdfTexture(Textures.createSDF, Textures.createComputeDepthTexture)
   Logic.connectTyping(
     Typing.enable,

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -1,81 +1,5 @@
-interface Point {
-  x: number
-  y: number
-}
-
-interface PointUV {
-  x: number
-  y: number
-  u: number
-  v: number
-}
-
-interface BoundingBox {
-  min_x: number
-  min_y: number
-  max_x: number
-  max_y: number
-}
-
-type Color = [number, number, number, number]
-type Id = [number, number, number, number]
-
+// types below does not need to be exported from this package
 type UiElementType = 0
-
-type GradientStop = {
-  color: Color
-  offset: number // 0..1
-}
-
-type LinearGradient = {
-  start: Point
-  end: Point
-  stops: GradientStop[]
-}
-
-type RadialGradient = {
-  radius_ratio: number
-  stops: GradientStop[]
-  center: Point
-  destination: Point
-}
-
-type SdfEffect = {
-  dist_start: number
-  dist_end: number
-  fill: { linear: LinearGradient } | { radial: RadialGradient } | { solid: Color }
-}
-
-type ShapeProps = {
-  sdf_effects: SdfEffect[]
-  filter: { gaussianBlur: Point } | null
-  opacity: number
-}
-
-type ImageAsset = {
-  id: number
-  bounds: PointUV[]
-  texture_id: number
-}
-
-type ShapeAsset = {
-  id: number
-  paths: Point[][]
-  props: ShapeProps
-  bounds: PointUV[] | null
-  sdf_texture_id: number
-  cache_texture_id: number | null
-}
-
-type TextAsset = {
-  id: number
-  content: string | null
-  bounds: PointUV[]
-  font_size: number
-  props: ShapeProps
-}
-
-type ZigAsset = { img: ImageAsset } | { shape: ShapeAsset } | { text: TextAsset }
 
 type ArrayPointerDataView = {
   '*': PointerDataView
@@ -96,22 +20,22 @@ declare module '*.zig' {
     max_texture_size: number,
     max_buffer_size: number
   ) => void
-  export const addImage: (maybe_asset_id: number, bounds: PointUV[], texture_id: number) => void
+  export const addImage: (maybe_asset_id: number, bounds: zig.PointUV[], texture_id: number) => void
   export const updateCache: VoidFunction
   export const addShape: (
     maybe_asset_id: number,
-    paths: Point[][],
-    bounds: PointUV[] | null,
-    props: Partial<ShapeProps>,
+    paths: zig.Point[][],
+    bounds: zig.PointUV[] | null,
+    props: Partial<zig.ShapeProps>,
     sdf_texture_id: number,
     cache_texture_id: null | number
   ) => number /* id */
   export const addShapeBegin: VoidFunction
   export const addShapeFinish: VoidFunction
   export const removeAsset: () => void
-  export const resetAssets: (assets: ZigAsset[], with_snapshot: boolean) => void
+  export const resetAssets: (assets: zig.ZigAsset[], with_snapshot: boolean) => void
 
-  export const onUpdatePick: (id: Id) => void
+  export const onUpdatePick: (id: zig.Id) => void
   export const onPointerDown: (x: number, y: number) => void
   export const onPointerUp: () => void
   export const onPointerMove: (x: number, y: number) => void
@@ -137,7 +61,7 @@ declare module '*.zig' {
     width: number
     height: number
     sdf_texture_id: number | null
-    setPaths(paths: Point[]): void // we have to call std.mem.Allocator.dupe() to allocate permament memory in zig
+    setPaths(paths: zig.Point[]): void // we have to call std.mem.Allocator.dupe() to allocate permament memory in zig
   }
 
   export const SerializedCharDetails: new ({
@@ -154,9 +78,9 @@ declare module '*.zig' {
     sdf_texture_id: number | null
   }) => SerializedCharDetails
 
-  export const Point: new ({ x, y }: { x: number; y: number }) => Point
+  export const Point: new ({ x, y }: { x: number; y: number }) => zig.Point
 
-  export const PtrI32: new (p: Point[][]) => Point[][]
+  export const PtrI32: new (p: zig.Point[][]) => zig.Point[][]
 
   export const connectWebGpuPrograms: (programs: {
     draw_texture: (vertex_data: PointerDataView, texture_id: number) => void
@@ -200,19 +124,19 @@ declare module '*.zig' {
       sdf_texture_id: number
     ) => void
   }) => void
-  export const connectOnAssetUpdateCallback: (cb: (data: ZigAsset[]) => void) => void
-  export const connectOnAssetSelectionCallback: (cb: (data: Id) => void) => void
+  export const connectOnAssetUpdateCallback: (cb: (data: zig.ZigAsset[]) => void) => void
+  export const connectOnAssetSelectionCallback: (cb: (data: zig.Id) => void) => void
   export const connectCreateSdfTexture: (
     createSdfTexture: () => number,
     createComputeDepthTexture: (width: number, height: number) => number
   ) => void
   export const connectCacheCallbacks: (
     create_cache_texture: () => number,
-    start_cache: (texture_id: number, box: BoundingBox, width: number, height: number) => void,
+    start_cache: (texture_id: number, box: zig.BoundingBox, width: number, height: number) => void,
     end_cache: VoidFunction
   ) => void
   export const connectSelectedAssetUpdates: (
-    on_selected_asset_update: (bounds: PointUV[] | null, props: ShapeProps | null) => void
+    on_selected_asset_update: (bounds: zig.PointUV[] | null, props: zig.ShapeProps | null) => void
   ) => void
   export const connectTyping: (
     enable: (text: string) => void,
@@ -233,12 +157,12 @@ declare module '*.zig' {
 
   export const importUiElement: (
     id: UiElementType,
-    paths: Point[][],
+    paths: zig.Point[][],
     sdf_texture_id: number
   ) => void
   export const generateUiElementsSdf: VoidFunction
 
   export const toggleSharedTextEffects: VoidFunction
-  export const setSelectedAssetProps: (props: Partial<ShapeProps>) => void
-  export const setSelectedAssetBounds: (bounds: PointUV[]) => void
+  export const setSelectedAssetProps: (props: Partial<zig.ShapeProps>) => void
+  export const setSelectedAssetBounds: (bounds: zig.PointUV[]) => void
 }

--- a/src/pointer.ts
+++ b/src/pointer.ts
@@ -1,6 +1,7 @@
 import * as Logic from 'logic/index.zig'
 import clamp from './utils/clamp'
 import * as Typing from './typing'
+import { Point } from 'types'
 
 const OUTSIDE_CANVAS = -1
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -23,6 +23,7 @@ import * as Logic from 'logic/index.zig'
 import { pointer } from 'pointer'
 import * as Textures from 'textures'
 import { endCache, startCache } from 'WebGPU/textureCache'
+import { BoundingBox, Point } from 'types'
 
 let renderPass: GPURenderPassEncoder
 export function updateRenderPass(newRenderPass: GPURenderPassEncoder) {

--- a/src/sanitizeFill.ts
+++ b/src/sanitizeFill.ts
@@ -1,3 +1,5 @@
+import { SdfEffect } from 'types'
+
 export default function sanitizeFill(fill: SdfEffect['fill']): SdfEffect['fill'] {
   if ('solid' in fill && fill.solid) {
     return { solid: [...fill.solid] }

--- a/src/svgToShapes/boundingBox.ts
+++ b/src/svgToShapes/boundingBox.ts
@@ -1,3 +1,4 @@
+import { Point } from 'types'
 import { isStraightHandle } from './utils'
 
 /**

--- a/src/svgToShapes/collectShapesData.ts
+++ b/src/svgToShapes/collectShapesData.ts
@@ -11,6 +11,7 @@ import {
 import * as radialGradient from './radialGradient'
 import { Def, Defs, DefStop } from './definitions'
 import getProps from './getProps'
+import { Point, SdfEffect, ShapeProps } from 'types'
 
 export interface ShapeData {
   paths: Point[][]

--- a/src/svgToShapes/definitions.ts
+++ b/src/svgToShapes/definitions.ts
@@ -1,6 +1,7 @@
 import { Node } from 'svg-parser'
 import { isElementNode } from './utils'
 import getProps from './getProps'
+import { Color, Point } from 'types'
 
 export type DefStop = {
   offset: number

--- a/src/svgToShapes/getProps.ts
+++ b/src/svgToShapes/getProps.ts
@@ -4,6 +4,7 @@ import parseEllipse from './parseEllipse'
 import parsePathData from './parsePathData'
 import parseRect from './parseRect'
 import { getNum, isElementNode, parseColor, parseTransform } from './utils'
+import { Color } from 'types'
 
 export default function getProps(node: ElementNode): Def {
   let rawProps = node.properties

--- a/src/svgToShapes/parseEllipse.ts
+++ b/src/svgToShapes/parseEllipse.ts
@@ -1,3 +1,5 @@
+import { Point } from 'types'
+
 export default function parseEllipse(cx: number, cy: number, rx: number, ry: number): Point[] {
   // Magic number for cubic Bezier approximation of a circle/ellipse
   // This creates a very close approximation using 4 cubic Bezier curves

--- a/src/svgToShapes/parsePathData.ts
+++ b/src/svgToShapes/parsePathData.ts
@@ -1,3 +1,4 @@
+import { Point } from 'types'
 import arcToBezier from './arcToBezier'
 import { STRAIGHT_LINE_HANDLE } from './const'
 

--- a/src/svgToShapes/parseRect.ts
+++ b/src/svgToShapes/parseRect.ts
@@ -1,3 +1,4 @@
+import { Point } from 'types'
 import { STRAIGHT_LINE_HANDLE } from './const'
 
 export default function parseRect(x: number, y: number, width: number, height: number): Point[] {

--- a/src/svgToShapes/radialGradient.ts
+++ b/src/svgToShapes/radialGradient.ts
@@ -1,3 +1,5 @@
+import { Point } from 'types'
+
 /**
  * Get the distance and ratio between two points for radial gradient
  * When shape's boundary has aspect ratio different than 1:1,

--- a/src/svgToShapes/utils.ts
+++ b/src/svgToShapes/utils.ts
@@ -1,5 +1,6 @@
 import { ElementNode, Node } from 'svg-parser'
 import { AttrValue } from './definitions'
+import { Color, Point } from 'types'
 
 const STRAIGHT_LINE_THRESHOLD = 1e10
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,142 @@
 export interface HTMLInputEvent extends Event {
   target: HTMLInputElement & EventTarget
 }
+
+export interface Point {
+  x: number
+  y: number
+}
+
+export interface PointUV {
+  x: number
+  y: number
+  u: number
+  v: number
+}
+
+export interface BoundingBox {
+  min_x: number
+  min_y: number
+  max_x: number
+  max_y: number
+}
+
+export type Color = [number, number, number, number]
+export type Id = [number, number, number, number]
+
+export type GradientStop = {
+  color: Color
+  offset: number // 0..1
+}
+
+export type LinearGradient = {
+  start: Point
+  end: Point
+  stops: GradientStop[]
+}
+
+export type RadialGradient = {
+  radius_ratio: number
+  stops: GradientStop[]
+  center: Point
+  destination: Point
+}
+
+export type SdfEffect = {
+  dist_start: number
+  dist_end: number
+  fill: { linear: LinearGradient } | { radial: RadialGradient } | { solid: Color }
+}
+
+export type ShapeProps = {
+  sdf_effects: SdfEffect[]
+  filter: { gaussianBlur: Point } | null
+  opacity: number
+}
+
+export type SerializedInputImage = {
+  id?: number // not needed while loading project but useful for undo/redo to maintain selection
+  bounds?: PointUV[]
+  url: string
+  texture_id?: number
+}
+
+export type SerializedInputShape = {
+  id?: number // not needed while loading project but useful for undo/redo to maintain selection
+  paths: Point[][]
+  props: ShapeProps
+  sdf_texture_id?: number
+  cache_texture_id?: number | null
+  bounds: PointUV[]
+}
+
+export type SerializedInputText = {
+  id?: number // not needed while loading project but useful for undo/redo to maintain selection
+  content: string
+  bounds: PointUV[]
+  font_size: number
+  props: ShapeProps
+}
+
+export type SerializedInputAsset = SerializedInputImage | SerializedInputShape | SerializedInputText
+
+export type SerializedOutputImage = {
+  id: number // not needed while loading project but useful for undo/redo to maintain selection
+  bounds: PointUV[]
+  url: string
+  texture_id: number
+}
+
+export type SerializedOutputShape = {
+  id: number // not needed while loading project but useful for undo/redo to maintain selection
+  paths: Point[][]
+  props: ShapeProps
+  bounds: PointUV[]
+  sdf_texture_id: number
+  cache_texture_id: number | null
+}
+
+export type SerializedOutputText = {
+  id: number // not needed while loading project but useful for undo/redo to maintain selection
+  content: string
+  bounds: PointUV[]
+  font_size: number
+  props: ShapeProps
+}
+
+export type SerializedOutputAsset =
+  | SerializedOutputImage
+  | SerializedOutputShape
+  | SerializedOutputText
+
+export enum CreatorTool {
+  SelectAsset = 0,
+  DrawBezierCurve = 1,
+  SelectNode = 2,
+  Text = 3,
+}
+
+type ImageAsset = {
+  id: number
+  bounds: PointUV[]
+  texture_id: number
+}
+
+type ShapeAsset = {
+  id: number
+  paths: Point[][]
+  props: ShapeProps
+  bounds: PointUV[] | null
+  sdf_texture_id: number
+  cache_texture_id: number | null
+}
+
+type TextAsset = {
+  id: number
+  content: string | null
+  bounds: PointUV[]
+  font_size: number
+  props: ShapeProps
+}
+
+export type ZigAsset = { img: ImageAsset } | { shape: ShapeAsset } | { text: TextAsset }

--- a/src/utils/distancePointToLine.ts
+++ b/src/utils/distancePointToLine.ts
@@ -1,3 +1,5 @@
+import { Point } from 'types'
+
 export default function distancePointToLine(p: Point, l1: Point, l2: Point) {
   const A = l2.y - l1.y
   const B = l1.x - l2.x

--- a/src/utils/getAngle.ts
+++ b/src/utils/getAngle.ts
@@ -1,3 +1,5 @@
+import { Point } from 'types'
+
 export default function getAngle(from: Point, to: Point) {
   return Math.atan2(to.y - from.y, to.x - from.x)
 }

--- a/src/utils/getBezierPos.ts
+++ b/src/utils/getBezierPos.ts
@@ -1,3 +1,5 @@
+import { Point } from 'types'
+
 export default function getBezierPos(p1: Point, p2: Point, p3: Point, p4: Point, t: number): Point {
   const t2 = t * t
   const one_minus_t = 1.0 - t

--- a/src/utils/getBezierTan.ts
+++ b/src/utils/getBezierTan.ts
@@ -1,3 +1,4 @@
+import { Point } from 'types'
 import normalizeVec2 from './normalizeVec2'
 
 export default function getBezierTan(p1: Point, p2: Point, p3: Point, p4: Point, t: number): Point {

--- a/src/utils/getCurveLength.ts
+++ b/src/utils/getCurveLength.ts
@@ -1,3 +1,4 @@
+import { Point } from 'types'
 import getBezierPos from './getBezierPos'
 
 // precision describes how many samples on the curve we want to measure to calculate whole length

--- a/src/utils/getDefaultPoints.ts
+++ b/src/utils/getDefaultPoints.ts
@@ -1,3 +1,4 @@
+import { PointUV } from 'types'
 import clamp from 'utils/clamp'
 
 export default function getDefaultPoints(

--- a/src/utils/getDistance.ts
+++ b/src/utils/getDistance.ts
@@ -1,3 +1,5 @@
+import { Point } from 'types'
+
 export default function getDistance(p1: Point, p2: Point) {
   return Math.hypot(p1.x - p2.x, p1.y - p2.y)
 }

--- a/src/utils/normalizeVec2.ts
+++ b/src/utils/normalizeVec2.ts
@@ -1,3 +1,5 @@
+import { Point } from 'types'
+
 export default function normalizeVec2(vec: Point): Point {
   const length = Math.sqrt(vec.x * vec.x + vec.y * vec.y)
   return {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,7 +6,8 @@
     "declarationMap": true,
     "declarationDir": "./lib/types"
   },
-  "include": ["src/**/*", "global.d.ts"] // this field is the main purpose of this separation
+  // actually maybe src/index.ts should be included?
+  "include": ["src/**/*", "global.d.ts", "modules.d.ts"] // this field is the main purpose of this separation
   // between tsconfig.json and tsconfig.build.json
-  // we don't want to geenrate type declarations for ALL the files in this project
+  // we don't want to generate type declarations for ALL the files in this project
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["es2020"],
     "outDir": "./lib",
     "sourceMap": true,
     "module": "ESNext", // normally it would be es6, but because of dynamic import it need to be something modern
@@ -7,16 +8,18 @@
     "allowJs": true,
     "moduleResolution": "bundler",
     "baseUrl": "./src",
-    "typeRoots": ["./node_modules/@webgpu/types", "./node_modules/@types"], // added because of WebGPU types. Also had to add node_modules/@types, because typeRoots override default typeRoots, not extends
+    "typeRoots": ["./node_modules/@webgpu/types"], // added because of WebGPU types.
+    // Also we should add node_modules/@types, because typeRoots override default typeRoots, not extends
+    // BUT it makes impossible to exclude "node_modules/@types/jsdom" which throws issues while during compilation in TS definition
+    "skipLibCheck": false, // we need this to check out local .d.ts ambient definition for *.zig
 
     // everything below is just suggested by https://www.npmjs.com/package/@tsconfig/recommended
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
   "$schema": "https://json.schemastore.org/tsconfig", // @tsconfig/recommended
   "display": "Recommended", // @tsconfig/recommended
 
-  "exclude": ["src/suspended/**/*"]
+  "exclude": ["src/suspended/**/*", "lib"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Import asset files (*.wgsl, *.svg, *.ttf) as strings.
  - Added normalizeVec2(vec) utility.
  - Exposed Point in the public API.

- Refactor
  - Centralized and re-exported types from a unified types module.
  - Introduced global zig.* namespace for shared types.
  - Updated public typings to use zig.* and Id; onAssetSelect now receives Id.

- Chores
  - Updated TypeScript config: ES2020 lib, stricter lib checks, adjusted type roots, and included new declaration file in build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->