### PR TITLE
fix: update keyboard event, notify about updates also when updates is trig…

### DIFF
--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1475,7 +1475,66 @@ pub fn setSelectedAssetProps(ser_props: asset_props.SerializedProps) !void {
 }
 
 pub fn setSelectedAssetBounds(bounds: [4]types.PointUV) !void {
+    // pub fn setSelectedAssetBounds(
+    //     offset_x: f32,
+    //     offset_y: f32,
+    //     origin: u32, // 0 -> Move, 1-9 -> transform ui handles
+    // ) !void {
+    // const asset = getSelectedAsset() orelse return;
+    // const bounds = asset.getBoundsPtr();
+
+    // const handle = switch (origin) {
+    //     1 => bounds[0].toPoint(),
+    //     2 => bounds[1].toPoint(),
+    //     3 => bounds[2].toPoint(),
+    //     4 => bounds[3].toPoint(),
+    //     5 => bounds[0].mid(bounds[1]),
+    //     6 => bounds[1].mid(bounds[2]),
+    //     7 => bounds[2].mid(bounds[3]),
+    //     8 => bounds[3].mid(bounds[0]),
+    //     else => @panic("Invalid origin"),
+    // };
+
+    // switch (state.action) {
+    //     .Move => {
+    //         for (bounds) |*point| {
+    //             point.x += offset_x;
+    //             point.y += offset_y;
+    //         }
+
+    //         asset_observer.triggerUpdate();
+    //     },
+    //     .Transform => {
+    //         transform_ui.transformPoints(
+    //             origin,
+    //             bounds,
+    //             types.Point{ .x = offset_x, .y = offset_y },
+    //         );
+    //         switch (asset.*) {
+    //             .img => {},
+    //             .shape => |*shape| {
+    //                 shape.should_update_sdf = true;
+    //             },
+    //             .text => |*text| {
+    //                 const result = try text.computeText(
+    //                     texts.caret_position,
+    //                     texts.selection_end_position,
+    //                 );
+
+    //                 if (state.tool == .Text) {
+    //                     update_text_content(result.content);
+    //                 }
+    //             },
+    //         }
+
+    //         asset_observer.triggerUpdate();
+    //     },
+    //     .TextSelection => {},
+    //     .None => {},
+    // }
+
     // TODO: code duplication with transform_ui
+
     if (getSelectedAsset()) |asset| {
         switch (asset.*) {
             .img => |*img| {
@@ -1500,8 +1559,7 @@ pub fn setSelectedAssetBounds(bounds: [4]types.PointUV) !void {
     }
 
     try checkAssetsUpdate(true);
-    // asset_observer.triggerUpdate(); not sure if we sould perform it or nothing
-    // we might ruin UX for the user while they are editing
+    asset_observer.triggerUpdate();
 }
 
 pub fn toggleSharedTextEffects() void {

--- a/src/pointer.ts
+++ b/src/pointer.ts
@@ -184,16 +184,15 @@ export default function initMouseController(
     const notTypingKeys = event.ctrlKey || event.code === 'AltLeft' || event.code === 'AltRight'
     if (Typing.isEnabled() && !notTypingKeys) return
 
-    switch (event.code) {
-      case 'Space':
+    switch (event.key) {
+      case ' ':
         event.preventDefault()
         if (mouseMode !== MouseMode.Pan) {
           canvas.style.cursor = 'grab'
           mouseMode = MouseMode.Pan
         }
         break
-      case 'AltLeft':
-      case 'AltRight':
+      case 'Alt':
         event.preventDefault()
         mouseMode = MouseMode.Zoom
         break
@@ -202,7 +201,7 @@ export default function initMouseController(
         Logic.commitChanges()
         break
       case '=':
-      case '+':
+        // case '+':
         // Zoom in with Ctrl/Cmd + Plus
         if (event.ctrlKey || event.metaKey) {
           event.preventDefault()
@@ -212,7 +211,7 @@ export default function initMouseController(
         }
         break
       case '-':
-      case '_':
+        // case '_':
         // Zoom out with Ctrl/Cmd/Shift + Minus
         if (event.ctrlKey || event.metaKey || event.shiftKey) {
           event.preventDefault()
@@ -221,13 +220,17 @@ export default function initMouseController(
           performZoom(-0.1, centerX, centerY)
         }
         break
+      case 'Meta': {
+        // update the way transform works
+      }
     }
   })
+
   document.body.addEventListener('keyup', (event) => {
-    if (event.code === 'Space' || event.key === 'Alt') {
+    if (event.key === ' ' || event.key === 'Alt') {
       mouseMode = MouseMode.None
     }
-    if (event.code === 'Space' && panCameraStart === null) {
+    if (event.key === ' ' && panCameraStart === null) {
       canvas.style.cursor = 'default'
     }
   })


### PR DESCRIPTION
…gered via API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canvas now refreshes immediately after adjusting selected asset bounds.
  * Keyboard shortcuts made consistent across layouts by using key values:
    - Space: hold to pan (grab cursor), release to reset.
    - Alt: hold to zoom, release to reset.
    - Ctrl/Cmd + =: zoom in centered on pointer/canvas.
    - Ctrl/Cmd + -: zoom out centered on pointer/canvas.
  * Key release reliably restores mouse mode and cursor when panning isn’t active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->