### PR TITLE
fix: Wait for textures to be loaded to generate a preview

### DIFF
--- a/src/WebGPU/getDevice.ts
+++ b/src/WebGPU/getDevice.ts
@@ -14,6 +14,7 @@ export default async function getDevice() {
     requiredFeatures: hasBGRA8unormStorage ? ['bgra8unorm-storage'] : [],
     label: 'id: ' + Date.now(),
   })
+
   device.lost.then((info) => {
     console.error(`WebGPU device was lost: ${info.message}`)
 

--- a/src/WebGPU/pick.ts
+++ b/src/WebGPU/pick.ts
@@ -41,7 +41,7 @@ export default class PickManager {
   startPicking(encoder: GPUCommandEncoder): { pass: GPURenderPassEncoder; end: VoidFunction } {
     const descriptor: GPURenderPassDescriptor = {
       // describe which textures we want to raw to and how use them
-      label: 'our render to canvas renderPass',
+      label: 'render pick',
       colorAttachments: [
         {
           view: this.pickTexture.createView(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,10 +72,7 @@ export default async function initCreator(
   Textures.init(device, presentationFormat, storageFormat, (texLoadings) => {
     texturesLoading = texLoadings
     updateIsProcessingFlag()
-
-    if (texturesLoading == 0) {
-      triggerGeneratePreview()
-    }
+    triggerGeneratePreview()
   })
 
   // rotation doesnt work

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export default async function initCreator(
   uploadTexture: (url: string, onNewUrl: (newUrl: string) => void) => void,
   onAssetsUpdate: (assets: SerializedOutputAsset[]) => void,
   onAssetSelect: (assetId: Id) => void,
-  onProcessingUpdate: (inProgress: boolean) => void,
+  onIsProcessingFlagUpdate: (inProgress: boolean) => void,
   onPreviewUpdate: (canvas: HTMLCanvasElement) => void,
   onUpdateTool: (tool: CreatorTool) => void,
   onUpdateProps: (bounds: PointUV[] | null, props: Partial<ShapeProps> | null) => void
@@ -50,13 +50,13 @@ export default async function initCreator(
   // including modifications caused by calling "updateAssetProps"
   // also called with null when no asset is selected
 ): Promise<CreatorAPI> {
-  let loadingTextures = 0
+  let texturesLoading = 0
   let isMouseEventProcessing = false
 
-  function updateProcessing() {
-    onProcessingUpdate(loadingTextures > 0 || isMouseEventProcessing)
+  function updateIsProcessingFlag() {
+    onIsProcessingFlagUpdate(texturesLoading > 0 || isMouseEventProcessing)
   }
-
+  let isDestroyed = false
   const { device, presentationFormat, storageFormat } = await getDevice()
 
   const projectWidth = canvas.clientWidth / 2
@@ -70,8 +70,12 @@ export default async function initCreator(
   )
 
   Textures.init(device, presentationFormat, storageFormat, (texLoadings) => {
-    loadingTextures = texLoadings
-    updateProcessing()
+    texturesLoading = texLoadings
+    updateIsProcessingFlag()
+
+    if (texturesLoading == 0) {
+      triggerGeneratePreview()
+    }
   })
 
   // rotation doesnt work
@@ -103,10 +107,12 @@ export default async function initCreator(
 
   initMouseController(canvas, updateRenderScale, () => {
     isMouseEventProcessing = true
-    updateProcessing()
+    updateIsProcessingFlag()
   })
 
-  const triggerGeneratePreview = throttle(() => {
+  const throttledPreviewGenerator = throttle(() => {
+    if (isDestroyed || texturesLoading > 0) return
+
     generatePreview(
       device,
       presentationFormat,
@@ -120,6 +126,12 @@ export default async function initCreator(
       onPreviewUpdate
     )
   }, 1000 * 5)
+
+  const triggerGeneratePreview = () => {
+    if (texturesLoading === 0) {
+      throttledPreviewGenerator()
+    }
+  }
 
   let lastAssetsSnapshot: ZigAsset[] = []
   Logic.connectOnAssetUpdateCallback((serializedData: ZigAsset[]) => {
@@ -209,14 +221,14 @@ export default async function initCreator(
 
   const { stopRAF, capturePreview } = runCreator(canvas, context, device, () => {
     isMouseEventProcessing = false
-    updateProcessing()
+    updateIsProcessingFlag()
   })
 
   const resetAssets: CreatorAPI['resetAssets'] = async (assets, withSnapshot = false) => {
     const results = await Promise.allSettled(
       assets.map<Promise<ZigAsset>>(
         (asset) =>
-          new Promise((resolve, reject) => {
+          new Promise((resolve) => {
             if ('paths' in asset) {
               // it's a shape
               return resolve({
@@ -289,6 +301,7 @@ export default async function initCreator(
     removeAsset: Logic.removeAsset,
     resetAssets,
     destroy: () => {
+      isDestroyed = true
       stopRAF()
       Logic.deinitState()
       context.unconfigure()

--- a/src/textures.ts
+++ b/src/textures.ts
@@ -30,9 +30,9 @@ function extractSizeFromSvgViewbox(viewbox: string) {
 
 let device: GPUDevice
 let textures: TextureSource[]
-let loadingTexture: GPUTexture
+let texturePlaceholder: GPUTexture
 let updateProcessing: () => void
-let loadingTextures: number
+let texturesLoading: number
 let presentationFormat: GPUTextureFormat
 let storageFormat: GPUTextureFormat
 
@@ -46,9 +46,9 @@ export function init(
   presentationFormat = _presentationFormat
   storageFormat = _storageFormat
   textures = []
-  loadingTexture = getLoadingTexture(device, presentationFormat)
-  updateProcessing = () => _updateProcessing(loadingTextures)
-  loadingTextures = 0
+  texturePlaceholder = getLoadingTexture(device, presentationFormat)
+  texturesLoading = 0
+  updateProcessing = () => _updateProcessing(texturesLoading)
 
   addIcon(0, RotateIcon)
 }
@@ -76,27 +76,39 @@ export function add(
   url: string,
   onLoad?: (width: number, height: number, isNew: boolean) => void
 ): number {
-  loadingTextures++
-  updateProcessing()
-
   const sameUrl = textures.find((t) => t.url === url)
   if (sameUrl) {
-    loadingTextures--
-    updateProcessing()
     onLoad?.(sameUrl.texture!.width, sameUrl.texture!.height, false)
     return textures.indexOf(sameUrl)
   }
 
+  texturesLoading++
+  updateProcessing()
+
   const textureId = textures.length
   // we allow duplicates in textures array
   textures.push({ url })
+  resolveTexture(url, textureId, onLoad)
 
-  getImageWithDetails(url).then(([img, svgTree]) => {
+  return textureId
+}
+
+async function resolveTexture(
+  url: string,
+  textureId: number,
+  onLoad?: (width: number, height: number, isNew: boolean) => void
+) {
+  try {
+    const [img, svgTree] = await Promise.all([getImage(url), getSvgRoot(url)])
     let existingTexture: TextureSource | null = null
     if (svgTree) {
       const svgRoot = svgTree.children[0] as ElementNode
       const [svgWidth, svgHeight] = getSvgSize(svgRoot, img)
-      if (!svgWidth || !svgHeight) throw Error('SVG width and height are required')
+
+      if (!svgWidth || !svgHeight) {
+        throw Error('SVG width and height are required')
+      }
+
       const defs: Defs = {}
       def.collect(svgRoot, defs)
       def.resolveAll(defs)
@@ -106,8 +118,6 @@ export function add(
       Logic.addShapeFinish()
 
       // onLoad is not called on purpose, it's unnecessary for shapes
-      loadingTextures--
-      updateProcessing()
       return
     }
 
@@ -127,11 +137,11 @@ export function add(
     }
 
     onLoad?.(img.width, img.height, !existingTexture)
-    loadingTextures--
+  } finally {
+    texturesLoading--
     updateProcessing()
-  })
-
-  return textureId
+    console.log('Resolve texture', url, texturesLoading)
+  }
 }
 
 export function getTexture(textureId: number): GPUTexture {
@@ -141,7 +151,7 @@ export function getTexture(textureId: number): GPUTexture {
 }
 
 export function getTextureSafe(textureId: number): GPUTexture {
-  return getOptionTexture(textureId) ?? loadingTexture
+  return getOptionTexture(textureId) ?? texturePlaceholder
 }
 
 export function getOptionTexture(textureId: number): GPUTexture | undefined {
@@ -299,24 +309,21 @@ export function updateTextureUrl(textureId: number, url: string) {
   textures[textureId].url = url
 }
 
-async function getImageWithDetails(url: string): Promise<[HTMLImageElement, RootNode | null]> {
-  return Promise.all([
-    new Promise<HTMLImageElement>((resolve) => {
-      const img = new Image()
-      img.crossOrigin = 'anonymous'
-      img.src = url
-      img.onload = () => resolve(img)
-    }),
-    new Promise<RootNode | null>((resolve) => {
-      fetch(url)
-        .then((response) => response.text())
-        .then((text) => {
-          if (text.includes('<svg')) {
-            resolve(parse(text))
-          } else {
-            resolve(null)
-          }
-        })
-    }),
-  ])
+function getImage(url: string): Promise<HTMLImageElement> {
+  return new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image()
+    img.crossOrigin = 'anonymous'
+    img.src = url
+    img.onload = () => resolve(img)
+    img.onerror = (err) => reject(err)
+  })
+}
+
+async function getSvgRoot(url: string): Promise<RootNode | null> {
+  const response = await fetch(url)
+  const text = await response.text()
+  if (text.includes('<svg')) {
+    return parse(text)
+  }
+  return null
 }

--- a/src/textures.ts
+++ b/src/textures.ts
@@ -140,7 +140,6 @@ async function resolveTexture(
   } finally {
     texturesLoading--
     updateProcessing()
-    console.log('Resolve texture', url, texturesLoading)
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed initialization callback: `onProcessingUpdate` → `onIsProcessingFlagUpdate`.

* **New Features**
  * Added WebGPU device loss detection to improve stability during GPU issues.

* **Improvements**
  * More robust texture loading and state tracking.
  * Smarter preview generation timing to reduce unnecessary work and improve responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->