### PR TITLE
fix: include is_shared_sdf in snapshots

### DIFF
--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -77,9 +77,9 @@ async function test() {
       window.lastSnapshot.assets.some((asset) => {
         if (asset.id === selectedAssetId && 'content' in asset) {
           sharedTextEffects.checked = asset.typo_props.is_sdf_shared
+          return true
         }
-
-        return asset
+        return false
       })
     },
     (inProgress) => {

--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -73,6 +73,14 @@ async function test() {
     (assetId) => {
       selectedAssetEl.textContent = assetId.toString()
       selectedAssetId = assetId[0]
+
+      window.lastSnapshot.assets.some((asset) => {
+        if (asset.id === selectedAssetId && 'content' in asset) {
+          sharedTextEffects.checked = asset.typo_props.is_sdf_shared
+        }
+
+        return asset
+      })
     },
     (inProgress) => {
       isProcessingEventsEl.textContent = inProgress ? 'true' : 'false'
@@ -159,7 +167,26 @@ async function test() {
   })
 
   sharedTextEffects.addEventListener('change', () => {
-    creator.toggleSharedTextEffects()
+    const newAssets = window.lastSnapshot.assets.map((asset) => {
+      if (asset.id === selectedAssetId && 'content' in asset) {
+        return {
+          ...asset,
+          typo_props: {
+            ...asset.typo_props,
+            is_sdf_shared: sharedTextEffects.checked,
+          },
+        }
+      }
+
+      return asset
+    })
+    creator.setSnapshot(
+      {
+        ...window.lastSnapshot,
+        assets: newAssets,
+      },
+      true
+    )
   })
 
   assetPropsForm.addEventListener('submit', function (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   ProjectSnapshot,
   SerializedAsset,
   ShapeProps,
+  TypoProps,
   ZigAsset,
   ZigProjectSnapshot,
 } from './types'
@@ -31,7 +32,6 @@ export interface CreatorAPI {
   removeAsset: VoidFunction
   destroy: VoidFunction
   setTool: (tool: CreatorTool) => void
-  toggleSharedTextEffects: VoidFunction
   // we need to obtain live update!
   updateAssetProps: (props: Partial<ShapeProps>, commit: boolean) => void // updates properties of selected asset
   updateAssetBounds: (bounds: PointUV[], commit: boolean) => void // updates bounds of selected asset
@@ -177,8 +177,9 @@ export default async function initCreator(
           id: asset.text.id,
           content: asset.text.content ?? '',
           bounds: serializeBounds([...asset.text.bounds]),
-          font_size: asset.text.font_size,
+          typo_props: serializeTypoProps(asset.text.typo_props),
           props: serializeShapeProps(asset.text.props),
+          sdf_texture_id: asset.text.sdf_texture_id,
         }
       } else {
         throw Error('Unknown asset type')
@@ -273,8 +274,9 @@ export default async function initCreator(
                   id: asset.id || NO_ASSET_ID,
                   content: asset.content,
                   bounds: asset.bounds,
-                  font_size: asset.font_size,
+                  typo_props: asset.typo_props,
                   props: asset.props,
+                  sdf_texture_id: asset.sdf_texture_id,
                 },
               })
             }
@@ -361,7 +363,6 @@ export default async function initCreator(
       onUpdateTool(tool)
       Logic.setTool(tool)
     },
-    toggleSharedTextEffects: Logic.toggleSharedTextEffects,
     updateAssetProps: Logic.setSelectedAssetProps,
     updateAssetBounds: Logic.setSelectedAssetBounds,
   }
@@ -392,5 +393,13 @@ function serializeShapeProps(props: ShapeProps): ShapeProps {
         }
       : null,
     opacity: props.opacity,
+  }
+}
+
+function serializeTypoProps(props: TypoProps): TypoProps {
+  return {
+    font_size: props.font_size,
+    line_height: props.line_height,
+    is_sdf_shared: props.is_sdf_shared,
   }
 }

--- a/src/logic/asset_props.zig
+++ b/src/logic/asset_props.zig
@@ -35,6 +35,13 @@ pub const Props = struct {
             .opacity = self.opacity,
         };
     }
+
+    pub fn deinit(self: *Props) void {
+        for (self.sdf_effects.items) |*effect| {
+            effect.fill.deinit();
+        }
+        self.sdf_effects.deinit();
+    }
 };
 
 pub const SerializedProps = struct {

--- a/src/logic/asset_props.zig
+++ b/src/logic/asset_props.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
-const sdf = @import("./sdf/sdf.zig");
-const fill = @import("./sdf/fill.zig");
-const types = @import("./types.zig");
-const utils = @import("./utils.zig");
+const sdf = @import("sdf/sdf.zig");
+const fill = @import("sdf/fill.zig");
+const types = @import("types.zig");
+const utils = @import("utils.zig");
 
 pub const SerializedSdfEffect = struct {
     dist_start: f32,

--- a/src/logic/default_matrix.zig
+++ b/src/logic/default_matrix.zig
@@ -1,4 +1,4 @@
-const Matrix3x3 = @import("./matrix.zig").Matrix3x3;
+const Matrix3x3 = @import("matrix.zig").Matrix3x3;
 const std = @import("std");
 
 pub fn getDefaultMatrix(

--- a/src/logic/images.zig
+++ b/src/logic/images.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Types = @import("types.zig");
 const PointUV = Types.PointUV;
-const utils = @import("./utils.zig");
+const utils = @import("utils.zig");
 
 const SHADER_TRIANGLE_INDICES = [_]usize{
     0, 1, 2,

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -160,7 +160,6 @@ declare module '*.zig' {
   ) => void
   export const generateUiElementsSdf: VoidFunction
 
-  export const toggleSharedTextEffects: VoidFunction
   export const setSelectedAssetProps: (props: Partial<zig.ShapeProps>, commit: boolean) => void
   export const setSelectedAssetBounds: (bounds: zig.PointUV[], commit: boolean) => void
 }

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1355,6 +1355,7 @@ pub fn setSelectedAssetProps(serialized_props: asset_props.SerializedProps, comm
                 // img.props = props;
             },
             .shape => |*shape| {
+                shape.props.deinit();
                 shape.props = try asset_props.deserializeProps(serialized_props, std.heap.page_allocator);
                 if (serialized_props.filter == null and shape.cache_texture_id != null) {
                     // TODO: https://github.com/mateuszJS/magic-render/issues/204
@@ -1367,6 +1368,7 @@ pub fn setSelectedAssetProps(serialized_props: asset_props.SerializedProps, comm
                 shape.outdated_sdf = true;
             },
             .text => |*text| {
+                text.props.deinit();
                 text.props = try asset_props.deserializeProps(serialized_props, std.heap.page_allocator);
                 if (text.typo_props.is_sdf_shared) {
                     text.is_sdf_outdated = true;

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -5,14 +5,14 @@ const lines = @import("lines.zig");
 const triangles = @import("triangles.zig");
 const transform_ui = @import("transform_ui.zig");
 const zigar = @import("zigar");
-const shapes = @import("./shapes/shapes.zig");
+const shapes = @import("shapes/shapes.zig");
 const rects = @import("rects.zig");
 const bounding_box = @import("shapes/bounding_box.zig");
 const shared = @import("shared.zig");
 const texture_size = @import("texture_size.zig");
-const Utils = @import("utils.zig");
+const utils = @import("utils.zig");
 const Matrix3x3 = @import("matrix.zig").Matrix3x3;
-const PathUtils = @import("shapes/path_utils.zig");
+const path_utils = @import("shapes/path_utils.zig");
 const consts = @import("consts.zig");
 const UI = @import("ui.zig");
 const texts = @import("texts/texts.zig");
@@ -25,6 +25,8 @@ const asset_props = @import("asset_props.zig");
 const snapshots = @import("snapshots.zig");
 const ActionType = @import("types.zig").ActionType;
 const Tool = @import("types.zig").Tool;
+const typography_props = @import("texts/typography_props.zig");
+const js_glue = @import("js_glue.zig");
 
 const FillType = enum(u8) {
     Solid,
@@ -68,14 +70,12 @@ pub fn connectOnAssetSelectionCallback(cb: *const fn ([4]u32) void) void {
     on_asset_select_cb = cb;
 }
 
-var create_sdf_texture: *const fn () u32 = undefined;
-var create_compute_depth_texture: *const fn (u32, u32) u32 = undefined;
 pub fn connectCreateSdfTexture(
     create_sdf: *const fn () u32,
     create_compute_depth: *const fn (u32, u32) u32,
 ) void {
-    create_sdf_texture = create_sdf;
-    create_compute_depth_texture = create_compute_depth;
+    js_glue.create_sdf_texture = create_sdf;
+    js_glue.create_compute_depth_texture = create_compute_depth;
 }
 
 var on_update_tool: *const fn (u16) void = undefined;
@@ -237,8 +237,9 @@ fn addText(
     id_or_zero: u32,
     content: []const u8,
     bounds: [4]types.PointUV,
-    font_size: f32,
     props: asset_props.SerializedProps,
+    typo_props: typography_props.Serialized,
+    sdf_texture_id: ?u32,
 ) !texts.Text {
     const id = if (id_or_zero == 0) generateId() else id_or_zero;
     const text = try texts.Text.new(
@@ -246,9 +247,9 @@ fn addText(
         id,
         content,
         bounds,
-        font_size,
         props,
-        null,
+        typo_props,
+        sdf_texture_id,
     );
     try state.assets.put(id, Asset{ .text = text });
     snapshots.triggerNewSnapshot(true, true);
@@ -358,13 +359,19 @@ fn createText(x: f32, y: f32) !texts.Text {
         },
     };
 
+    const typo_props = typography_props.Serialized{
+        .font_size = 72,
+        .line_height = 1.2,
+        .is_sdf_shared = true,
+    };
+
     return try addText(
         id,
         try std.heap.wasm_allocator.dupe(u8, "H"),
-        // "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         bounds,
-        72,
         props,
+        typo_props,
+        null,
     );
 }
 
@@ -418,7 +425,7 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                 &.{},
                 consts.DEFAULT_BOUNDS,
                 props,
-                create_sdf_texture(),
+                js_glue.create_sdf_texture(),
                 if (props.filter != null) create_cache_texture() else null,
             );
             try setSelectedAsset(AssetId{ ._prim = id });
@@ -520,13 +527,13 @@ pub fn onPointerMove(x: f32, y: f32) !void {
 
                     const option_index = if (i == 0 and path.closed) points.len - 1 else if (i > 0) i - 1 else null;
                     if (option_index) |index| {
-                        if (!PathUtils.isStraightLineHandle(points[index])) {
+                        if (!path_utils.isStraightLineHandle(points[index])) {
                             points[index].x += diff.x;
                             points[index].y += diff.y;
                         }
                     }
                     if (i + 1 < points.len - 1) {
-                        if (!PathUtils.isStraightLineHandle(points[i + 1])) {
+                        if (!path_utils.isStraightLineHandle(points[i + 1])) {
                             points[i + 1].x += diff.x;
                             points[i + 1].y += diff.y;
                         }
@@ -542,14 +549,14 @@ pub fn onPointerMove(x: f32, y: f32) !void {
                     };
 
                     if (option_index) |index| {
-                        const opposite_handler = PathUtils.getOppositeHandle(
+                        const opposite_handler = path_utils.getOppositeHandle(
                             cp,
                             points[i],
                         );
 
                         const dist = opposite_handler.distance(points[index]);
                         if (dist < 1.0) {
-                            points[index] = PathUtils.getOppositeHandle(
+                            points[index] = path_utils.getOppositeHandle(
                                 cp,
                                 pointer,
                             );
@@ -739,7 +746,7 @@ fn requestCharsSdfs() !void {
                         const ch_d = try fonts.get(0, char);
 
                         ch_d.request_size(
-                            text.font_size,
+                            text.typo_props.font_size,
                             padding,
                         );
                     }
@@ -770,7 +777,7 @@ pub fn computeSdfs() !void {
                 const ch_w = font_size * ch_d.width;
                 const ch_h = font_size * ch_d.height;
 
-                const bounds = Utils.createBounds(ch_w, ch_h);
+                const bounds = utils.createBounds(ch_w, ch_h);
                 const padding = font_size * ch_d.*.max_ratio_padding_to_font_size;
                 const sdf_dims = sdf.getSdfTextureDims(bounds, padding);
 
@@ -784,7 +791,7 @@ pub fn computeSdfs() !void {
                 const points = try allocator.dupe(types.Point, ch_d.points);
 
                 for (points) |*point| {
-                    if (PathUtils.isStraightLineHandle(point.*)) continue;
+                    if (path_utils.isStraightLineHandle(point.*)) continue;
                     point.x = (point.x * real_viewport_font_size) + viewport_padding;
                     point.y = (point.y * real_viewport_font_size) + viewport_padding;
                 }
@@ -841,8 +848,10 @@ pub fn computeSdfs() !void {
                 shape.should_update_sdf = false;
             },
             .text => |*text| {
-                if (text.sdf_texture_id) |text_sdf_texture_id| {
+                if (text.typo_props.is_sdf_shared) {
                     if (!text.is_sdf_outdated) continue;
+
+                    const text_sdf_texture_id = text.getSdfTextureId();
 
                     const text_padding = sdf.getSdfPadding(text.props.sdf_effects.items);
                     const sdf_dims = sdf.getSdfTextureDims(
@@ -853,7 +862,7 @@ pub fn computeSdfs() !void {
 
                     const bounds_height = text.bounds[0].distance(text.bounds[3]);
 
-                    const compute_depth_texture_id = create_compute_depth_texture(
+                    const compute_depth_texture_id = js_glue.create_compute_depth_texture(
                         @intFromFloat(sdf_dims.size.w),
                         @intFromFloat(sdf_dims.size.h),
                     );
@@ -870,7 +879,7 @@ pub fn computeSdfs() !void {
                             const ch_d = try fonts.get(0, char);
 
                             if (ch_d.sdf_texture_id) |char_sdf_texture_id| {
-                                const char_padding = text.font_size * ch_d.max_ratio_padding_to_font_size;
+                                const char_padding = text.typo_props.font_size * ch_d.max_ratio_padding_to_font_size;
 
                                 const start_x = vertex.relative_bounds[3].x - char_padding;
                                 const start_y = bounds_height + vertex.relative_bounds[3].y - char_padding;
@@ -1050,7 +1059,9 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
             .text => |*text| {
                 const is_typing_ui = state.tool == .Text and state.selected_asset_id.getPrim() == text.id;
 
-                if (text.sdf_texture_id) |sdf_texture_id| {
+                if (text.typo_props.is_sdf_shared) {
+                    const text_sdf_texture_id = text.getSdfTextureId();
+
                     const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
                     for (text.props.sdf_effects.items) |effect| {
                         const text_bounds = sdf.getDrawBounds(
@@ -1061,7 +1072,7 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
                         web_gpu_programs.draw_shape(
                             &text_bounds,
                             text.getDrawUniform(effect, text.sdf_scale),
-                            sdf_texture_id,
+                            text_sdf_texture_id,
                         );
                     }
 
@@ -1076,14 +1087,14 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
 
                 for (text.text_vertex.items, 0..) |vertex, i| {
                     if (vertex.char) |char| {
-                        if (text.sdf_texture_id == null) {
+                        if (!text.typo_props.is_sdf_shared) {
                             const ch_d = try fonts.get(0, char);
 
                             if (ch_d.sdf_texture_id) |sdf_texture_id| {
                                 for (text.props.sdf_effects.items) |effect| {
-                                    const bounds = vertex.getBoundsVertex(text.font_size * ch_d.max_ratio_padding_to_font_size, matrix);
+                                    const bounds = vertex.getBoundsVertex(text.typo_props.font_size * ch_d.max_ratio_padding_to_font_size, matrix);
                                     const char_sdf_viewport_font_size = ch_d.max_font_size * ch_d.sdf_scale;
-                                    const sdf_scale = char_sdf_viewport_font_size / text.font_size;
+                                    const sdf_scale = char_sdf_viewport_font_size / text.typo_props.font_size;
 
                                     web_gpu_programs.draw_shape(
                                         &bounds,
@@ -1123,7 +1134,7 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
                         else
                             types.Point{
                                 .x = 0,
-                                .y = -text.font_size * text.line_height,
+                                .y = -text.typo_props.font_size * text.typo_props.line_height,
                             };
                     if (text.addCaretDrawVertex(position)) |buffer| {
                         try vertex_triangles_buffer.appendSlice(&buffer);
@@ -1273,8 +1284,9 @@ pub fn setSnapshot(snapshot: snapshots.ProjectSnapshot, with_snapshot: bool) !vo
                     text.id,
                     text.content orelse "",
                     text.bounds,
-                    text.font_size,
                     text.props,
+                    text.typo_props,
+                    text.sdf_texture_id,
                 );
             },
         }
@@ -1335,7 +1347,7 @@ pub fn tick(now: f32) !void {
     try snapshots.loop(state);
 }
 
-pub fn setSelectedAssetProps(ser_props: asset_props.SerializedProps, commit: bool) !void {
+pub fn setSelectedAssetProps(serialized_props: asset_props.SerializedProps, commit: bool) !void {
     if (getSelectedAsset()) |asset| {
         switch (asset.*) {
             .img => |img| {
@@ -1343,20 +1355,20 @@ pub fn setSelectedAssetProps(ser_props: asset_props.SerializedProps, commit: boo
                 // img.props = props;
             },
             .shape => |*shape| {
-                shape.props = try asset_props.deserializeProps(ser_props, std.heap.page_allocator);
-                if (ser_props.filter == null and shape.cache_texture_id != null) {
+                shape.props = try asset_props.deserializeProps(serialized_props, std.heap.page_allocator);
+                if (serialized_props.filter == null and shape.cache_texture_id != null) {
                     // TODO: https://github.com/mateuszJS/magic-render/issues/204
                     // destroy_texture(shape.cache_texture_id);
 
                     shape.cache_texture_id = null;
-                } else if (ser_props.filter != null and shape.cache_texture_id == null) {
+                } else if (serialized_props.filter != null and shape.cache_texture_id == null) {
                     shape.cache_texture_id = create_cache_texture();
                 }
                 shape.outdated_sdf = true;
             },
             .text => |*text| {
-                text.props = try asset_props.deserializeProps(ser_props, std.heap.page_allocator);
-                if (text.sdf_texture_id != null) {
+                text.props = try asset_props.deserializeProps(serialized_props, std.heap.page_allocator);
+                if (text.typo_props.is_sdf_shared) {
                     text.is_sdf_outdated = true;
                 }
             },
@@ -1451,15 +1463,4 @@ pub fn setSelectedAssetBounds(bounds: [4]types.PointUV, commit: bool) !void {
     }
 
     snapshots.triggerNewSnapshot(true, commit);
-}
-
-pub fn toggleSharedTextEffects() void {
-    if (getSelectedText()) |text| {
-        if (text.sdf_texture_id != null) {
-            text.sdf_texture_id = null;
-        } else {
-            text.sdf_texture_id = create_sdf_texture();
-            text.is_sdf_outdated = true;
-        }
-    }
 }

--- a/src/logic/js_glue.zig
+++ b/src/logic/js_glue.zig
@@ -1,0 +1,2 @@
+pub var create_sdf_texture: *const fn () u32 = undefined;
+pub var create_compute_depth_texture: *const fn (u32, u32) u32 = undefined;

--- a/src/logic/lines.zig
+++ b/src/logic/lines.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const Point = @import("types.zig").Point;
-const Utils = @import("utils.zig");
 const triangles = @import("triangles.zig");
 
 fn getPoints(start: anytype, end: anytype, width: f32, rounded: f32) [4]triangles.RoundCorner {

--- a/src/logic/rects.zig
+++ b/src/logic/rects.zig
@@ -1,6 +1,5 @@
 const Point = @import("types.zig").Point;
 const PointUV = @import("types.zig").PointUV;
-const Utils = @import("utils.zig");
 const math = @import("std").math;
 const std = @import("std");
 const triangles = @import("triangles.zig");

--- a/src/logic/shapes/bounding_box.zig
+++ b/src/logic/shapes/bounding_box.zig
@@ -1,6 +1,6 @@
 const Point = @import("../types.zig").Point;
 const std = @import("std");
-const PathUtils = @import("path_utils.zig");
+const path_utils = @import("path_utils.zig");
 
 /// Represents a 2D bounding box with minimum and maximum coordinates
 pub const BoundingBox = struct {
@@ -134,11 +134,11 @@ pub fn getBoundingBox(curves: []const Point) BoundingBox {
         const p3 = curves[i * 4 + 3];
 
         // Do we need this? How did it worked before????? Wit treating stright handles as any point
-        if (PathUtils.isStraightLineHandle(p1)) {
+        if (path_utils.isStraightLineHandle(p1)) {
             // If p1 is a straight line handle, we skip it
             p1 = p0; // Use p0 as the first point
         }
-        if (PathUtils.isStraightLineHandle(p2)) {
+        if (path_utils.isStraightLineHandle(p2)) {
             // If p2 is a straight line handle, we skip it
             p2 = p3; // Use p3 as the last point
         }

--- a/src/logic/shapes/paths.zig
+++ b/src/logic/shapes/paths.zig
@@ -1,4 +1,3 @@
-const Utils = @import("../utils.zig");
 const Point = @import("../types.zig").Point;
 const std = @import("std");
 const bounding_box = @import("bounding_box.zig");
@@ -6,7 +5,7 @@ const triangles = @import("../triangles.zig");
 const lines = @import("../lines.zig");
 const shared = @import("../shared.zig");
 const Matrix3x3 = @import("../matrix.zig").Matrix3x3;
-const PathUtils = @import("path_utils.zig");
+const path_utils = @import("path_utils.zig");
 const AssetId = @import("../asset_id.zig").AssetId;
 
 pub const Path = struct {
@@ -16,7 +15,7 @@ pub const Path = struct {
     pub fn new(point: Point, allocator: std.mem.Allocator) !Path {
         var point_list = std.ArrayList(Point).init(allocator);
         try point_list.append(point);
-        try point_list.append(PathUtils.STRAIGHT_LINE_HANDLE);
+        try point_list.append(path_utils.STRAIGHT_LINE_HANDLE);
 
         const shape = Path{
             .points = point_list,
@@ -46,11 +45,11 @@ pub const Path = struct {
             // but adding more points always ends path with a control point, not handle at the end
             const prev_handle = self.points.items[self.points.items.len - 2];
             const last_cp = self.points.getLast();
-            const next_handle = PathUtils.getOppositeHandle(last_cp, prev_handle);
+            const next_handle = path_utils.getOppositeHandle(last_cp, prev_handle);
             try self.points.append(next_handle);
         }
 
-        try self.points.append(PathUtils.STRAIGHT_LINE_HANDLE);
+        try self.points.append(path_utils.STRAIGHT_LINE_HANDLE);
 
         const first_p = self.points.items[0];
         if (@abs(first_p.x - point.x) < same_point_threshold.x and @abs(first_p.y - point.y) < same_point_threshold.y) {
@@ -70,7 +69,7 @@ pub const Path = struct {
     fn getNextHandle(self: Path, i: usize, with_preview: bool) ?Point {
         const points = self.points.items;
         if (i + 1 <= points.len - 1) return points[i + 1];
-        if (i != 0 and with_preview and !self.closed) return PathUtils.getOppositeHandle(points[i], points[i - 1]);
+        if (i != 0 and with_preview and !self.closed) return path_utils.getOppositeHandle(points[i], points[i - 1]);
         return null;
     }
 
@@ -91,7 +90,7 @@ pub const Path = struct {
                 };
                 for (&handles) |*handle| {
                     if (handle.*) |h| {
-                        if (PathUtils.isStraightLineHandle(h)) {
+                        if (path_utils.isStraightLineHandle(h)) {
                             handle.* = null;
                         } else {
                             handle.* = matrix.get(h);
@@ -99,7 +98,7 @@ pub const Path = struct {
                     }
                 }
 
-                try PathUtils.drawControlPoint(
+                try path_utils.drawControlPoint(
                     i,
                     self.points.items.len,
                     cp,
@@ -122,7 +121,7 @@ pub const Path = struct {
     ) ![]triangles.PickInstance {
         var skeleton_buffer = std.ArrayList(triangles.PickInstance).init(allocator);
         for (self.points.items, 0..) |relative_point, i| {
-            if (PathUtils.isStraightLineHandle(relative_point)) {
+            if (path_utils.isStraightLineHandle(relative_point)) {
                 // This is a straight line handle, skip it
                 continue;
             }
@@ -130,7 +129,7 @@ pub const Path = struct {
             const point = matrix.get(relative_point);
             const is_control_point = i % 3 == 0;
             const id = [4]u32{ shape_id, path_index + 1, i + 1, 0 };
-            const buffer = PathUtils.getVertexPickSkeletonPoint(is_control_point, point, id);
+            const buffer = path_utils.getVertexPickSkeletonPoint(is_control_point, point, id);
             try skeleton_buffer.appendSlice(&buffer);
         }
 
@@ -160,17 +159,17 @@ pub const Path = struct {
                 if (points.len > 2) {
                     const last_cp = self.points.getLast();
                     const last_handle = points[points.len - 2];
-                    try buffer.append(PathUtils.getOppositeHandle(last_cp, last_handle));
+                    try buffer.append(path_utils.getOppositeHandle(last_cp, last_handle));
                 }
-                try buffer.append(PathUtils.STRAIGHT_LINE_HANDLE);
+                try buffer.append(path_utils.STRAIGHT_LINE_HANDLE);
                 try buffer.append(preview);
                 try buffer.append(preview);
             }
 
             if (points.len > 2 or preview_point != null) {
-                try buffer.append(PathUtils.STRAIGHT_LINE_HANDLE);
+                try buffer.append(path_utils.STRAIGHT_LINE_HANDLE);
             }
-            try buffer.append(PathUtils.STRAIGHT_LINE_HANDLE);
+            try buffer.append(path_utils.STRAIGHT_LINE_HANDLE);
         }
 
         try buffer.append(points[0]);
@@ -180,7 +179,7 @@ pub const Path = struct {
         const points = self.points.items;
 
         const cp = if (self.closed) points[0] else points[points.len - 1];
-        const opposite_handle = PathUtils.getOppositeHandle(cp, preview_point);
+        const opposite_handle = path_utils.getOppositeHandle(cp, preview_point);
 
         if (self.closed) {
             points[1] = preview_point;

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -11,7 +11,7 @@ const shared = @import("../shared.zig");
 const images = @import("../images.zig");
 const Matrix3x3 = @import("../matrix.zig").Matrix3x3;
 const consts = @import("../consts.zig");
-const PathUtils = @import("path_utils.zig");
+const path_utils = @import("path_utils.zig");
 const fill = @import("../sdf/fill.zig");
 const sdf = @import("../sdf/sdf.zig");
 const AssetId = @import("../asset_id.zig").AssetId;
@@ -157,7 +157,7 @@ pub const Shape = struct {
                 if (dist > CREATE_HANDLE_THRESHOLD) {
                     self.updateLastHandle(p);
                 } else {
-                    self.updateLastHandle(PathUtils.STRAIGHT_LINE_HANDLE);
+                    self.updateLastHandle(path_utils.STRAIGHT_LINE_HANDLE);
                 }
             }
         } else {
@@ -201,7 +201,7 @@ pub const Shape = struct {
         // Normalize points to [0,1] range
         for (self.paths.items) |*path| {
             for (path.points.items) |*p| {
-                if (PathUtils.isStraightLineHandle(p.*)) continue;
+                if (path_utils.isStraightLineHandle(p.*)) continue;
                 p.x = (p.x - box.min_x) / new_width;
                 p.y = (p.y - box.min_y) / new_height;
             }
@@ -218,7 +218,7 @@ pub const Shape = struct {
 
     fn updateLastHandle(self: *Shape, absolute_point: Point) void {
         if (active_path_index) |i| {
-            const point = if (PathUtils.isStraightLineHandle(absolute_point)) b: {
+            const point = if (path_utils.isStraightLineHandle(absolute_point)) b: {
                 break :b absolute_point;
             } else b: {
                 const matrix = Matrix3x3.getMatrixFromRectangle(self.bounds);
@@ -268,7 +268,7 @@ pub const Shape = struct {
 
         if (self.preview_point) |point| {
             if (!is_handle_preview) {
-                const buffer = PathUtils.getVertexDrawSkeletonPoint(true, point, false);
+                const buffer = path_utils.getVertexDrawSkeletonPoint(true, point, false);
                 try skeleton_buffer.appendSlice(&buffer);
             }
         }
@@ -277,7 +277,7 @@ pub const Shape = struct {
     }
 
     pub fn getSkeletonUniform(self: Shape) sdf.DrawUniform {
-        const stroke_width = PathUtils.SKELETON_LINE_WIDTH * self.sdf_scale * shared.render_scale;
+        const stroke_width = path_utils.SKELETON_LINE_WIDTH * self.sdf_scale * shared.render_scale;
         return sdf.DrawUniform{
             .solid = .{
                 .dist_start = stroke_width * 0.5,
@@ -324,7 +324,7 @@ pub const Shape = struct {
             try path.getClosedPathPoints(&points, preview_p);
         }
 
-        PathUtils.prepareHalfStraightLines(points.items);
+        path_utils.prepareHalfStraightLines(points.items);
 
         return points.toOwnedSlice();
     }

--- a/src/logic/snapshots.zig
+++ b/src/logic/snapshots.zig
@@ -1,6 +1,6 @@
 // This module is responsible to generate snapshots
 
-const Utils = @import("utils.zig");
+const utils = @import("utils.zig");
 const AssetSerialized = @import("types.zig").AssetSerialized;
 const State = @import("types.zig").State;
 const shared = @import("shared.zig");
@@ -107,7 +107,7 @@ fn generateNewSnapshot(state: State) !void {
 
     if (commit) {
         // if it's not a commit, then we do not care about limiting snapshots
-        const is_project_size_same = Utils.equalF32(last_project_snapshot.width, state.width) and Utils.equalF32(last_project_snapshot.height, state.height);
+        const is_project_size_same = utils.equalF32(last_project_snapshot.width, state.width) and utils.equalF32(last_project_snapshot.height, state.height);
         if (is_project_size_same and curr_snapshot.assets.len == last_project_snapshot.assets.len) {
             var all_match = true;
 

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -13,6 +13,8 @@ const Matrix3x3 = @import("../matrix.zig").Matrix3x3;
 const sdf = @import("../sdf/sdf.zig");
 const asset_props = @import("../asset_props.zig");
 const fill = @import("../sdf/fill.zig");
+const typography_props = @import("typography_props.zig");
+const js_glue = @import("../js_glue.zig");
 
 const ENTER_CHAR_CODE: u21 = 0xa;
 const SOFT_BREAK_MARKER: u21 = 0x2060;
@@ -55,29 +57,29 @@ pub const ComputeTextResult = struct {
 pub const Text = struct {
     id: u32,
     content: []const u8,
-    font_size: f32,
     bounds: [4]PointUV,
-    line_height: f32 = 1.2, // line height multiplier
     text_vertex: std.ArrayList(CharVertex),
 
     sdf_texture_id: ?u32 = null,
     sdf_scale: f32 = 1.0,
     is_sdf_outdated: bool = true,
+
     props: asset_props.Props,
+    typo_props: typography_props.Props,
 
     pub fn new(
         allocator: std.mem.Allocator,
         id: u32,
         content: []const u8,
         bounds: [4]PointUV,
-        font_size: f32,
         input_props: asset_props.SerializedProps,
+        input_typo_props: typography_props.Serialized,
         sdf_texture_id: ?u32,
     ) !Text {
         var text = Text{
             .id = id,
             .content = content,
-            .font_size = font_size,
+            .typo_props = typography_props.deserialize(input_typo_props),
             .bounds = bounds,
             .text_vertex = std.ArrayList(CharVertex).init(allocator),
             .props = try asset_props.deserializeProps(input_props, allocator),
@@ -90,11 +92,12 @@ pub const Text = struct {
     }
 
     fn getDrawRelativeBounds(self: Text, x: f32, y: f32, width: f32, height: f32, origin: Point) [4]PointUV {
-        const w = width * self.font_size;
-        const h = height * self.font_size;
+        const size = self.typo_props.font_size;
+        const w = width * size;
+        const h = height * size;
         const p = Point{
-            .x = origin.x + x * self.font_size,
-            .y = origin.y + y * self.font_size,
+            .x = origin.x + x * size,
+            .y = origin.y + y * size,
         };
         return [_]PointUV{
             .{ .x = p.x, .y = p.y + h, .u = 0.0, .v = 1.0 },
@@ -113,7 +116,7 @@ pub const Text = struct {
 
         self.text_vertex.clearAndFree();
 
-        const lh = self.font_size * self.line_height;
+        const lh = self.typo_props.font_size * self.typo_props.line_height;
         const max_text_width = self.bounds[0].distance(self.bounds[1]);
         var longest_line: f32 = 0.0;
         var next_pos = Point{ .x = 0, .y = -lh };
@@ -142,11 +145,11 @@ pub const Text = struct {
             if (new_selection_end == 0 and cp_index >= selection_end) new_selection_end = self.text_vertex.items.len;
 
             const char_details = try fonts.get(0, cp);
-            const char_width = (char_details.x + char_details.width) * self.font_size;
+            const char_width = (char_details.x + char_details.width) * self.typo_props.font_size;
 
             var space_before = if (option_prev_cp) |prev_cp| b: {
                 const kerning = try fonts.get_kerning(0, prev_cp, cp);
-                break :b kerning * self.font_size;
+                break :b kerning * self.typo_props.font_size;
             } else 0.0;
 
             const exceeded_max_width = (next_pos.x + space_before + char_width) > max_text_width;
@@ -257,7 +260,7 @@ pub const Text = struct {
             ch_vertex.origin.x,
             ch_vertex.origin.y,
             ch_vertex.relative_bounds[1].x - ch_vertex.origin.x,
-            self.font_size * self.line_height,
+            self.typo_props.font_size * self.typo_props.line_height,
             0.0,
             .{ 0, 100, 100, 100 },
         );
@@ -271,7 +274,7 @@ pub const Text = struct {
         const matrix = Matrix3x3.getMatrixFromRectangleNoScale(self.bounds);
         const relative_end = Point{
             .x = relative_start.x,
-            .y = relative_start.y + self.font_size * self.line_height,
+            .y = relative_start.y + self.typo_props.font_size * self.typo_props.line_height,
         };
 
         const CARET_BLINK_INTERVAL_MS = 700;
@@ -309,6 +312,14 @@ pub const Text = struct {
         }
 
         return null;
+    }
+
+    pub fn getSdfTextureId(self: *Text) u32 {
+        return if (self.sdf_texture_id) |sdf_texture_id| sdf_texture_id else b: {
+            const sdf_tex_id = js_glue.create_sdf_texture();
+            self.sdf_texture_id = sdf_tex_id;
+            break :b sdf_tex_id;
+        };
     }
 
     pub fn addPickVertex(
@@ -358,7 +369,7 @@ pub const Text = struct {
                     vertex.origin.x - left_additional_offset,
                     vertex.origin.y,
                     half_width + left_additional_offset,
-                    self.line_height * self.font_size,
+                    self.typo_props.line_height * self.typo_props.font_size,
                     0.0,
                     .{ self.id, valid_pick_index, 0, 0 },
                 ));
@@ -374,7 +385,7 @@ pub const Text = struct {
                     char_x,
                     vertex.origin.y,
                     half_width + right_additional_offset,
-                    self.line_height * self.font_size,
+                    self.typo_props.line_height * self.typo_props.font_size,
                     0.0,
                     .{ self.id, valid_pick_index + 1, 0, 0 },
                 ));
@@ -413,9 +424,10 @@ pub const Text = struct {
         return Serialized{
             .id = self.id,
             .content = self.content,
-            .font_size = self.font_size,
             .bounds = self.bounds,
             .props = props,
+            .typo_props = self.typo_props.serialize(),
+            .sdf_texture_id = self.sdf_texture_id,
         };
     }
 };
@@ -425,14 +437,15 @@ pub const Serialized = struct {
     content: ?[]const u8, // it's a null pointer exception for case when content is empty, we allow null
     // to avoid throwing the exception by Zigar
     bounds: [4]PointUV,
-    font_size: f32,
     props: asset_props.SerializedProps,
+    typo_props: typography_props.Serialized,
+    sdf_texture_id: ?u32,
 
     pub fn compare(self: Serialized, other: Serialized) bool {
         const all_match = self.id == other.id and
-            self.font_size == other.font_size and
             self.props.compare(other.props) and
             utils.compareBounds(self.bounds, other.bounds) and
+            self.typo_props.compare(other.typo_props) and
             std.mem.eql(u8, self.content orelse &.{}, other.content orelse &.{});
 
         return all_match;

--- a/src/logic/texts/typography_props.zig
+++ b/src/logic/texts/typography_props.zig
@@ -1,0 +1,37 @@
+const utils = @import("../utils.zig");
+
+pub const Props = struct {
+    font_size: f32,
+    is_sdf_shared: bool,
+    line_height: f32,
+
+    pub fn serialize(self: Props) Serialized {
+        return Serialized{
+            .font_size = self.font_size,
+            .is_sdf_shared = self.is_sdf_shared,
+            .line_height = self.line_height,
+        };
+    }
+};
+
+pub const Serialized = struct {
+    font_size: f32,
+    is_sdf_shared: bool,
+    line_height: f32,
+
+    pub fn compare(self: Serialized, other: Serialized) bool {
+        const all_match = utils.equalF32(self.font_size, other.font_size) and
+            self.is_sdf_shared == other.is_sdf_shared and
+            utils.equalF32(self.line_height, other.line_height);
+
+        return all_match;
+    }
+};
+
+pub fn deserialize(serialized: Serialized) Props {
+    return Props{
+        .font_size = serialized.font_size,
+        .is_sdf_shared = serialized.is_sdf_shared,
+        .line_height = serialized.line_height,
+    };
+}

--- a/src/logic/triangles.zig
+++ b/src/logic/triangles.zig
@@ -1,6 +1,6 @@
 const Point = @import("types.zig").Point;
 const PointUV = @import("types.zig").PointUV;
-const Utils = @import("utils.zig");
+const utils = @import("utils.zig");
 const math = @import("std").math;
 const std = @import("std");
 
@@ -86,9 +86,9 @@ pub fn getRoundCornerVector(index: usize, points: [NUM_OF_POINTS]Point, radius: 
 
     const p_to_pa = p.angleTo(pa);
     const p_to_pb = p.angleTo(pb);
-    const mid_angle_p = Utils.findMidAngle(p_to_pa, p_to_pb);
+    const mid_angle_p = utils.findMidAngle(p_to_pa, p_to_pb);
 
-    const half_of_mid_angle_p = Utils.angleDifference(mid_angle_p, p_to_pa);
+    const half_of_mid_angle_p = utils.angleDifference(mid_angle_p, p_to_pa);
     const p0_circle_offset = radius / math.sin(half_of_mid_angle_p); // Pythagorean theorem
     const p_circle = Point{
         .x = p.x + math.cos(mid_angle_p) * p0_circle_offset,

--- a/src/logic/utils.zig
+++ b/src/logic/utils.zig
@@ -1,5 +1,5 @@
 const math = @import("std").math;
-const consts = @import("./consts.zig");
+const consts = @import("consts.zig");
 const PointUV = @import("types.zig").PointUV;
 
 pub fn findMidAngle(angle1: f32, angle2: f32) f32 {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,12 @@ export type ShapeProps = {
   opacity: number
 }
 
+export type TypoProps = {
+  font_size: number
+  line_height: number
+  is_sdf_shared: boolean
+}
+
 export type SerializedImage = {
   id?: number // not needed while loading project but useful for undo/redo to maintain selection
   bounds?: PointUV[]
@@ -74,8 +80,9 @@ export type SerializedText = {
   id?: number // not needed while loading project but useful for undo/redo to maintain selection
   content: string
   bounds: PointUV[]
-  font_size: number
   props: ShapeProps
+  typo_props: TypoProps
+  sdf_texture_id: number | null
 }
 
 export type SerializedAsset = SerializedImage | SerializedShape | SerializedText
@@ -106,8 +113,9 @@ type TextAsset = {
   id: number
   content: string | null
   bounds: PointUV[]
-  font_size: number
   props: ShapeProps
+  typo_props: TypoProps
+  sdf_texture_id: number | null
 }
 
 export type ZigAsset = { img: ImageAsset } | { shape: ShapeAsset } | { text: TextAsset }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text assets gain unified typography settings (font size, line-height, shared text-effects) and integrated SDF texture handling for consistent rendering and sizing.

* **API Changes**
  * Removed the public toggle for shared text effects from the Creator API; typography properties are now part of text asset serialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->