### PR TITLE
fix: remove blur event before

### DIFF
--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -637,7 +637,8 @@ pub fn commitChanges() !void {
         shapes.resetState();
     }
 
-    if (state.tool == Tool.Text) {
+    const is_text_area_enabled = state.tool == .Text and state.selected_asset_id.isSec();
+    if (is_text_area_enabled) {
         disable_typing();
         texts.caret_position = 0;
         texts.selection_end_position = 0;
@@ -1527,6 +1528,5 @@ pub fn onBlurTextArea() void {
         state.selected_asset_id = AssetId.fromArray(.{ state.selected_asset_id.getPrim(), 0, 0, 0 });
         texts.caret_position = 0;
         texts.selection_end_position = 0;
-        disable_typing();
     }
 }

--- a/src/typing.ts
+++ b/src/typing.ts
@@ -93,6 +93,11 @@ function onCopy(this: HTMLTextAreaElement, event: ClipboardEvent) {
   event.preventDefault()
 }
 
+function onBlur() {
+  Logic.onBlurTextArea()
+  disable()
+}
+
 export function enable(text: string): void {
   if (!textarea) {
     const newEl = document.createElement('textarea')
@@ -107,9 +112,7 @@ export function enable(text: string): void {
     newEl.addEventListener('input', onInput)
     newEl.addEventListener('selectionchange', onSelect)
     newEl.addEventListener('copy', onCopy)
-    newEl.addEventListener('blur', () => {
-      Logic.onBlurTextArea()
-    })
+    newEl.addEventListener('blur', onBlur)
 
     textarea = newEl
   }
@@ -120,6 +123,8 @@ export function enable(text: string): void {
 
 export function disable(): void {
   if (textarea) {
+    textarea.removeEventListener('blur', onBlur)
+    // otherwise removeChild will trigger onblur listener
     document.body.removeChild(textarea)
     textarea = null
   }

--- a/src/utils/decompressWoff2.mjs
+++ b/src/utils/decompressWoff2.mjs
@@ -385,7 +385,6 @@ function preRun() {
   callRuntimeCallbacks(__ATPRERUN__)
 }
 function initRuntime() {
-  runtimeInitialized = true
   callRuntimeCallbacks(__ATINIT__)
 }
 function postRun() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input state management to only disable typing when the text area is inactive, preventing unintended input restrictions.
  * Enhanced event listener cleanup during text area removal to eliminate spurious event invocations and ensure proper teardown behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->