### PR TITLE
fix: Copy memory in text.new

### DIFF
--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -307,7 +307,7 @@ pub fn updateTextContent(
 ) !texts.ComputeTextResult {
     const option_text = getSelectedText();
     if (option_text) |text| {
-        text.content = try std.heap.wasm_allocator.dupe(u8, input_content);
+        text.content = try std.heap.page_allocator.dupe(u8, input_content);
         // IMPORTANT: do NOT free input_content,
         // It's owned by Zigar/JS side, so hopefully it's gonna somehow handled there
         const results = try text.computeText(selection_start, selection_end);
@@ -362,7 +362,7 @@ fn createText(x: f32, y: f32) !texts.Text {
 
     return try addText(
         id,
-        try std.heap.wasm_allocator.dupe(u8, "H"),
+        "Type here",
         bounds,
         props,
         typo_props,
@@ -1293,7 +1293,7 @@ pub fn setSnapshot(snapshot: snapshots.ProjectSnapshot, with_snapshot: bool) !vo
             .text => |text| {
                 _ = try addText(
                     text.id,
-                    text.content orelse "",
+                    text.content orelse "", // should always be provided, important to be null in real life execution
                     text.bounds,
                     text.props,
                     text.typo_props,

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1293,7 +1293,7 @@ pub fn setSnapshot(snapshot: snapshots.ProjectSnapshot, with_snapshot: bool) !vo
             .text => |text| {
                 _ = try addText(
                     text.id,
-                    text.content orelse "", // should always be provided, important to be null in real life execution
+                    text.content orelse "", // should always be provided in real-life executions
                     text.bounds,
                     text.props,
                     text.typo_props,

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -307,6 +307,7 @@ pub fn updateTextContent(
 ) !texts.ComputeTextResult {
     const option_text = getSelectedText();
     if (option_text) |text| {
+        std.heap.page_allocator.free(text.content);
         text.content = try std.heap.page_allocator.dupe(u8, input_content);
         // IMPORTANT: do NOT free input_content,
         // It's owned by Zigar/JS side, so hopefully it's gonna somehow handled there

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -78,7 +78,7 @@ pub const Text = struct {
     ) !Text {
         var text = Text{
             .id = id,
-            .content = content,
+            .content = try allocator.dupe(u8, content),
             .typo_props = typography_props.deserialize(input_typo_props),
             .bounds = bounds,
             .text_vertex = std.ArrayList(CharVertex).init(allocator),
@@ -244,7 +244,7 @@ pub const Text = struct {
             try updated_content_bytes.appendSlice(utf8_buffer[0..utf8_len]);
         }
 
-        std.heap.wasm_allocator.free(self.content); // free previous content
+        std.heap.page_allocator.free(self.content); // free previous content
         self.content = try updated_content_bytes.toOwnedSlice();
 
         self.is_sdf_outdated = true;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated default placeholder text for newly created text assets from "H" to "Type here" for clearer guidance.
  * No other user-facing behavior or content fallback changes; existing text handling and snapshot fallbacks remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->