### PR TITLE
fix: split types and js into separate build files

### DIFF
--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -1,4 +1,5 @@
-import initCreator, { ProjectSnapshot } from '../src/index'
+import initCreator from '../src/index'
+import type { ProjectSnapshot } from '../src/types'
 import FontEBGaramond from './EBGaramond-VariableFont_wght.ttf'
 import FontGoogleSans from './GoogleSans-Regular.ttf'
 import OutfitWoff2 from './Outfit.woff2'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "engines": {
     "node": ">=20.8.1"
   },
+  "sideEffects": false,
   "publishConfig": {
     "access": "public",
     "provenance": true
@@ -57,8 +58,16 @@
     "webpack-dev-server": "^5.2.0",
     "zigar-loader": "^0.14.1"
   },
-  "types": "./lib/types/index.d.ts",
-  "main": "./lib/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/index.mjs"
+    },
+    "./types": {
+      "types": "./lib/types/types.d.ts",
+      "import": "./lib/types.mjs"
+    }
+  },
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,17 +10,7 @@ import throttle from 'utils/throttle'
 import generatePreview from 'WebGPU/generatePreview'
 import * as Typing from 'typing'
 import * as Fonts from 'fonts'
-import {
-  Asset,
-  CreatorTool,
-  Id,
-  PointUV,
-  ProjectSnapshot,
-  ShapeProps,
-  TypoProps,
-  ZigAsset,
-} from './types'
-export * from './types'
+import { Asset, CreatorAPI, CreatorTool, Id, ProjectSnapshot, ZigAsset } from './types'
 import { destroyCanvasTextures } from 'getCanvasRenderDescriptor'
 import setCamera from 'utils/setCamera'
 import { toZigShapeProps } from 'snapshots/convert'
@@ -28,20 +18,6 @@ import * as CustomPrograms from 'customPrograms'
 import * as Snapshots from 'snapshots/snapshots'
 import toZigAsset from 'snapshots/toZigAsset'
 import { NO_ASSET_ID } from 'consts'
-
-export interface CreatorAPI {
-  addImages: (urls: string[]) => void
-  setSnapshot: (snapshot: ProjectSnapshot, withSnapshot: boolean) => Promise<void>
-  removeAsset: VoidFunction
-  destroy: VoidFunction
-  setTool: (tool: CreatorTool) => void
-  // we need to obtain live update!
-  updateAssetTypoProps: (props: TypoProps, commit: boolean) => void // updates typography properties of selected asset
-  updateAssetProps: (props: ShapeProps, commit: boolean) => void // updates properties of selected asset
-  updateAssetBounds: (bounds: PointUV[], commit: boolean) => void // updates bounds of selected asset
-  INFINITE_DISTANCE_THRESHOLD: number // threshold value for considering a distance as "infinite" in SDF fill effects
-  INFINITE_DISTANCE: number // maximum f32 value, used for SDF fill effects
-}
 
 export default async function initCreator(
   initialProjectWidth: number, // we could also set size along setSnapshot, but

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,3 +169,17 @@ export interface ZigProjectSnapshot {
 }
 
 export type CustomProgramError = GPUCompilationMessage
+
+export interface CreatorAPI {
+  addImages: (urls: string[]) => void
+  setSnapshot: (snapshot: ProjectSnapshot, withSnapshot: boolean) => Promise<void>
+  removeAsset: VoidFunction
+  destroy: VoidFunction
+  setTool: (tool: CreatorTool) => void
+  // we need to obtain live update!
+  updateAssetTypoProps: (props: TypoProps, commit: boolean) => void // updates typography properties of selected asset
+  updateAssetProps: (props: ShapeProps, commit: boolean) => void // updates properties of selected asset
+  updateAssetBounds: (bounds: PointUV[], commit: boolean) => void // updates bounds of selected asset
+  INFINITE_DISTANCE_THRESHOLD: number // threshold value for considering a distance as "infinite" in SDF fill effects
+  INFINITE_DISTANCE: number // maximum f32 value, used for SDF fill effects
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,7 +171,7 @@ export interface ZigProjectSnapshot {
 export type CustomProgramError = GPUCompilationMessage
 
 export interface CreatorAPI {
-  addImages: (urls: string[]) => void
+  addImages: (urls: string[]) => Promise<void>
   setSnapshot: (snapshot: ProjectSnapshot, withSnapshot: boolean) => Promise<void>
   removeAsset: VoidFunction
   destroy: VoidFunction

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,10 +33,6 @@ const baseConfig = {
     },
     /* useful with absolute imports, "src" dir now takes precedence over "node_modules" */
   },
-  entry: {
-    index: './src/index.ts',
-    types: './src/types.ts',
-  },
   output: {
     filename: '[name].mjs',
     library: {
@@ -108,6 +104,10 @@ const baseConfig = {
 
 const libConfig = {
   ...baseConfig,
+  entry: {
+    index: './src/index.ts',
+    types: './src/types.ts',
+  },
   output: {
     ...baseConfig.output,
     path: path.resolve(__dirname, 'lib'),
@@ -117,7 +117,7 @@ const libConfig = {
 // Test config
 const testConfig = {
   ...baseConfig,
-  entry: { ...baseConfig.entry, integrationTest: './integration-tests/index.ts' },
+  entry: { integrationTest: './integration-tests/index.ts' },
   output: {
     ...baseConfig.output,
     path: path.resolve(__dirname, 'lib-test'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,10 @@ const baseConfig = {
     },
     /* useful with absolute imports, "src" dir now takes precedence over "node_modules" */
   },
+  entry: {
+    index: './src/index.ts',
+    types: './src/types.ts',
+  },
   output: {
     filename: '[name].mjs',
     library: {
@@ -104,7 +108,6 @@ const baseConfig = {
 
 const libConfig = {
   ...baseConfig,
-  entry: { index: './src/index.ts' },
   output: {
     ...baseConfig.output,
     path: path.resolve(__dirname, 'lib'),
@@ -114,7 +117,7 @@ const libConfig = {
 // Test config
 const testConfig = {
   ...baseConfig,
-  entry: { integrationTest: './integration-tests/index.ts' },
+  entry: { ...baseConfig.entry, integrationTest: './integration-tests/index.ts' },
   output: {
     ...baseConfig.output,
     path: path.resolve(__dirname, 'lib-test'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized public module entry points and exports for clearer packaging and resolution.
  * Consolidated and exposed type definitions in a dedicated types module and adjusted consumer imports.
  * Introduced a formal CreatorAPI surface in the types module.
  * Added build entry for type artifacts and enabled tree-shaking with sideEffects: false.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->