### PR TITLE
fix: extract effect to own file and field

### DIFF
--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -225,7 +225,7 @@ async function test() {
     const formData = new FormData(assetPropsForm)
     try {
       const newProps = JSON.parse(formData.get('code') as string)
-      creator.updateAssetProps(newProps, true)
+      creator.updateAssetProps(newProps, [], true)
     } catch (e) {
       alert('Cannot parse JSON: ' + (e as Error).message)
     }

--- a/src/customPrograms.ts
+++ b/src/customPrograms.ts
@@ -1,7 +1,7 @@
 import getDrawShape from 'WebGPU/programs/drawShape/getProgram'
 import customProgramWrapper from 'WebGPU/programs/drawShape/custom-program-wrapper.wgsl'
 import { device, presentationFormat } from 'WebGPU/device'
-import { Asset, CustomProgramError, SdfEffect } from 'types'
+import { Asset, CustomProgramError, Effect } from 'types'
 import drawShapeShaderBase from 'WebGPU/programs/drawShape/base.wgsl'
 
 interface CustomProgram {
@@ -125,7 +125,7 @@ export function getCustomProgram(programId: number): CustomProgram {
   return program
 }
 
-function getEffectWithError(effect: SdfEffect): SdfEffect {
+function getEffectWithError(effect: Effect): Effect {
   if ('program' in effect.fill && typeof effect.fill.program.id === 'number') {
     const program = getCustomProgram(effect.fill.program.id)
     return {
@@ -147,10 +147,7 @@ export function getAssetsWithError(assets: Asset[]) {
     'props' in asset
       ? {
           ...asset,
-          props: {
-            ...asset.props,
-            sdf_effects: asset.props.sdf_effects.map(getEffectWithError),
-          },
+          effects: asset.effects.map(getEffectWithError),
         }
       : asset
   )
@@ -160,7 +157,7 @@ export function getAssetIdsByProgramId(assets: Asset[], programId: number): numb
   return assets
     .filter((asset) => {
       if ('props' in asset) {
-        return [...asset.props.sdf_effects].some(
+        return asset.effects.some(
           (effect) => 'program' in effect.fill && effect.fill.program.id === programId
         )
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import * as Fonts from 'fonts'
 import { Asset, CreatorAPI, CreatorTool, Id, ProjectSnapshot, ZigAsset } from './types'
 import { destroyCanvasTextures } from 'getCanvasRenderDescriptor'
 import setCamera from 'utils/setCamera'
-import { toZigShapeProps } from 'snapshots/convert'
+import { toZigEffects, toZigShapeProps } from 'snapshots/convert'
 import * as CustomPrograms from 'customPrograms'
 import * as Snapshots from 'snapshots/snapshots'
 import toZigAsset from 'snapshots/toZigAsset'
@@ -260,8 +260,8 @@ export default async function initCreator(
       onUpdateTool(tool)
       Logic.setTool(tool)
     },
-    updateAssetProps: (props, commit) => {
-      Logic.setSelectedAssetProps(toZigShapeProps(props), commit)
+    updateAssetProps: (props, effects, commit) => {
+      Logic.setSelectedAssetProps(toZigShapeProps(props), toZigEffects(effects), commit)
     },
     updateAssetBounds: Logic.setSelectedAssetBounds,
     updateAssetTypoProps: (typoProps, commit) => {

--- a/src/logic/asset_props.zig
+++ b/src/logic/asset_props.zig
@@ -1,7 +1,6 @@
 // This file describes base properties shared among all the assets like opacity or blur
 
 const std = @import("std");
-const fill = @import("sdf/fill.zig");
 const types = @import("types.zig");
 const utils = @import("utils.zig");
 

--- a/src/logic/asset_props.zig
+++ b/src/logic/asset_props.zig
@@ -1,96 +1,31 @@
+// This file describes base properties shared among all the assets like opacity or blur
+
 const std = @import("std");
-const sdf = @import("sdf/sdf.zig");
 const fill = @import("sdf/fill.zig");
 const types = @import("types.zig");
 const utils = @import("utils.zig");
 
-pub const SerializedSdfEffect = struct {
-    dist_start: f32,
-    dist_end: f32,
-    fill: fill.SerializedFill,
-};
-
-pub const Filter = struct {
-    gaussianBlur: types.Point,
-};
-
 pub const Props = struct {
-    sdf_effects: std.ArrayList(sdf.Effect),
-    filter: ?Filter,
-    opacity: f32,
-
-    pub fn serialize(self: Props, allocator: std.mem.Allocator) !SerializedProps {
-        var effects_list = std.ArrayList(SerializedSdfEffect).init(allocator);
-        for (self.sdf_effects.items) |effect| {
-            try effects_list.append(SerializedSdfEffect{
-                .dist_start = effect.dist_start,
-                .dist_end = effect.dist_end,
-                .fill = try effect.fill.serialize(allocator),
-            });
-        }
-
-        return SerializedProps{
-            .sdf_effects = try effects_list.toOwnedSlice(),
-            .filter = self.filter,
-            .opacity = self.opacity,
-        };
-    }
-
-    pub fn deinit(self: *Props) void {
-        for (self.sdf_effects.items) |*effect| {
-            effect.fill.deinit();
-        }
-        self.sdf_effects.deinit();
-    }
-};
-
-pub const SerializedProps = struct {
-    sdf_effects: []const SerializedSdfEffect = &.{},
-    filter: ?Filter = null,
     opacity: f32 = 1.0,
+    blur: ?types.Point = null,
 
-    pub fn compare(self: SerializedProps, other: SerializedProps) bool {
-        if (!utils.equalF32(self.opacity, other.opacity)) return false;
+    pub fn compare(self: Props, other: Props) bool {
+        if (!utils.equalF32(self.opacity, other.opacity)) {
+            return false;
+        }
 
-        if (self.filter) |filter| {
-            if (other.filter) |other_filter| {
-                if (!utils.equalBoundPoint(filter.gaussianBlur, other_filter.gaussianBlur)) {
+        if (self.blur) |blur| {
+            if (other.blur) |other_blur| {
+                if (!utils.equalBoundPoint(blur, other_blur)) {
                     return false;
                 }
             } else {
                 return false;
             }
-        } else if (other.filter != null) {
+        } else if (other.blur != null) {
             return false;
-        }
-
-        if (self.sdf_effects.len != other.sdf_effects.len) return false;
-
-        for (self.sdf_effects, other.sdf_effects) |effect_a, effect_b| {
-            if (!utils.equalF32(effect_a.dist_start, effect_b.dist_start)) return false;
-            if (!utils.equalF32(effect_a.dist_end, effect_b.dist_end)) return false;
-            if (!effect_a.fill.compare(effect_b.fill)) return false;
         }
 
         return true;
     }
 };
-
-// This function cannot be part of SerializedProps struct because it returns []GradientStop(part of props.fill)
-// and there is no writer interface created(only []u8 can be returned as a slices)
-pub fn deserializeProps(self: SerializedProps, allocator: std.mem.Allocator) !Props {
-    var effects_list = std.ArrayList(sdf.Effect).init(allocator);
-    for (self.sdf_effects) |effect| {
-        try effects_list.append(sdf.Effect{
-            .dist_start = effect.dist_start,
-            .dist_end = effect.dist_end,
-            .fill = try fill.Fill.new(effect.fill, allocator),
-        });
-    }
-
-    return Props{
-        .sdf_effects = effects_list,
-        .filter = self.filter,
-        .opacity = self.opacity,
-    };
-}

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -16,7 +16,7 @@ type ShapeDrawUniform = OneOf<{
 }>
 
 declare module '*.zig' {
-  import { ZigProjectSnapshot, TypoProps, ZigShapeProps } from 'types'
+  import { ZigProjectSnapshot, TypoProps, ZigShapeProps, ZigEffect } from 'types'
 
   export const initState: (
     width: number,
@@ -162,7 +162,11 @@ declare module '*.zig' {
   ) => void
   export const generateUiElementsSdf: VoidFunction
 
-  export const setSelectedAssetProps: (props: ZigShapeProps, commit: boolean) => void
+  export const setSelectedAssetProps: (
+    props: ZigShapeProps,
+    effects: ZigEffect[],
+    commit: boolean
+  ) => void
   export const setSelectedAssetBounds: (bounds: zig.PointUV[], commit: boolean) => void
   export const setSelectedAssetTypoProps: (typo_props: TypoProps, commit: boolean) => void
 

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1325,7 +1325,7 @@ pub fn deinitState() void {
         switch (entry.value_ptr.*) {
             .img => {},
             .shape => |*shape| shape.deinit(),
-            .text => {},
+            .text => |*text| text.deinit(),
         }
     }
     state.assets.clearAndFree();

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -16,7 +16,7 @@ const path_utils = @import("shapes/path_utils.zig");
 const consts = @import("consts.zig");
 const UI = @import("ui.zig");
 const texts = @import("texts/texts.zig");
-const sdf = @import("sdf/sdf.zig");
+const sdf_drawing = @import("sdf/drawing.zig");
 const fonts = @import("texts/fonts.zig");
 const AssetId = @import("asset_id.zig").AssetId;
 const Asset = @import("types.zig").Asset;
@@ -27,6 +27,7 @@ const ActionType = @import("types.zig").ActionType;
 const Tool = @import("types.zig").Tool;
 const typography_props = @import("texts/typography_props.zig");
 const js_glue = @import("js_glue.zig");
+const sdf_effect = @import("sdf/effect.zig");
 
 const FillType = enum(u8) {
     Solid,
@@ -48,7 +49,7 @@ const WebGpuPrograms = struct {
     clear_sdf: *const fn (u32, u32, u32, u32) void,
     combine_sdf: *const fn (u32, u32, u32, Placement) void,
     draw_blur: *const fn (u32, u32, u32, u32, f32, f32) void,
-    draw_shape: *const fn ([]const types.PointUV, sdf.DrawUniform, u32) void,
+    draw_shape: *const fn ([]const types.PointUV, sdf_drawing.DrawUniform, u32) void,
     pick_texture: *const fn ([]const images.PickVertex, u32) void,
     pick_triangle: *const fn ([]const triangles.PickInstance) void,
     pick_shape: *const fn ([]const images.PickVertex, shapes.PickUniform, u32) void,
@@ -167,8 +168,8 @@ pub fn updateRenderScale(scale: f32) !void {
         switch (asset.value_ptr.*) {
             .img => {},
             .shape => |*shape| {
-                const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
-                const new_sdf_dims = sdf.getSdfTextureDims(
+                const sdf_padding = sdf_drawing.getSdfPadding(shape.effects.items);
+                const new_sdf_dims = sdf_drawing.getSdfTextureDims(
                     shape.bounds,
                     sdf_padding,
                 );
@@ -207,7 +208,8 @@ pub fn addShape(
     id_or_zero: u32,
     paths: []const []const types.Point,
     bounds: [4]types.PointUV,
-    props: asset_props.SerializedProps,
+    props: asset_props.Props,
+    effects: []const sdf_effect.Serialized,
     sdf_texture_id: u32,
     cache_texture_id: ?u32,
 ) !u32 {
@@ -217,6 +219,7 @@ pub fn addShape(
         paths,
         bounds,
         props,
+        effects,
         sdf_texture_id,
         cache_texture_id,
         std.heap.page_allocator,
@@ -231,7 +234,8 @@ fn addText(
     id_or_zero: u32,
     content: []const u8,
     bounds: [4]types.PointUV,
-    props: asset_props.SerializedProps,
+    props: asset_props.Props,
+    effects: []const sdf_effect.Serialized,
     typo_props: typography_props.Serialized,
     sdf_texture_id: ?u32,
 ) !texts.Text {
@@ -242,6 +246,7 @@ fn addText(
         content,
         bounds,
         props,
+        effects,
         typo_props,
         sdf_texture_id,
     );
@@ -329,28 +334,26 @@ fn createText(x: f32, y: f32) !texts.Text {
         .{ .x = x, .y = y - 1.0, .u = 0.0, .v = 0.0 },
     };
 
-    const props = asset_props.SerializedProps{
-        .sdf_effects = &.{
-            .{
-                .dist_start = INFINITE_DISTANCE,
-                .dist_end = 0,
-                .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
-            },
-            .{
-                .dist_start = 3,
-                .dist_end = 1.5,
-                .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
-            },
-            .{
-                .dist_start = -6,
-                .dist_end = -8,
-                .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
-            },
-            .{
-                .dist_start = -12,
-                .dist_end = -18,
-                .fill = .{ .solid = .{ 1.0, 1.0, 0.0, 1.0 } },
-            },
+    const effects: []const sdf_effect.Serialized = &.{
+        .{
+            .dist_start = INFINITE_DISTANCE,
+            .dist_end = 0,
+            .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
+        },
+        .{
+            .dist_start = 3,
+            .dist_end = 1.5,
+            .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+        },
+        .{
+            .dist_start = -6,
+            .dist_end = -8,
+            .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+        },
+        .{
+            .dist_start = -12,
+            .dist_end = -18,
+            .fill = .{ .solid = .{ 1.0, 1.0, 0.0, 1.0 } },
         },
     };
 
@@ -365,7 +368,8 @@ fn createText(x: f32, y: f32) !texts.Text {
         id,
         "Type here",
         bounds,
-        props,
+        asset_props.Props{},
+        effects,
         typo_props,
         null,
     );
@@ -396,33 +400,34 @@ pub fn onPointerDown(x: f32, y: f32) !void {
         state.action = .TextSelection;
     } else if (state.tool == Tool.DrawShape) {
         if (getSelectedShape() == null) {
-            const props = asset_props.SerializedProps{
-                .sdf_effects = &.{
-                    .{
-                        .dist_start = INFINITE_DISTANCE,
-                        .dist_end = 0,
-                        .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
-                    },
-                    .{
-                        .dist_start = 26,
-                        .dist_end = 24,
-                        .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
-                    },
-                    .{
-                        .dist_start = -30,
-                        .dist_end = -32,
-                        .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
-                    },
+            const props = asset_props.Props{
+                .blur = .{ .x = 30, .y = 30 },
+            };
+            const effects: []const sdf_effect.Serialized = &.{
+                .{
+                    .dist_start = INFINITE_DISTANCE,
+                    .dist_end = 0,
+                    .fill = .{ .solid = .{ 1.0, 0.0, 1.0, 1.0 } },
                 },
-                .filter = .{ .gaussianBlur = .{ .x = 30, .y = 30 } },
+                .{
+                    .dist_start = 26,
+                    .dist_end = 24,
+                    .fill = .{ .solid = .{ 1.0, 1.0, 1.0, 1.0 } },
+                },
+                .{
+                    .dist_start = -30,
+                    .dist_end = -32,
+                    .fill = .{ .solid = .{ 1.0, 0.0, 0.0, 1.0 } },
+                },
             };
             const id = try addShape(
                 0,
                 &.{},
                 consts.DEFAULT_BOUNDS,
                 props,
+                effects,
                 js_glue.create_sdf_texture(),
-                if (props.filter != null) create_cache_texture() else null,
+                if (props.blur != null) create_cache_texture() else null,
             );
             try setSelectedAsset(AssetId{ ._prim = id });
         }
@@ -743,7 +748,7 @@ fn requestCharsSdfs() !void {
                     continue;
                 }
 
-                const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
+                const padding = sdf_drawing.getSdfPadding(text.effects.items);
 
                 for (text.text_vertex.items) |vertex| {
                     if (vertex.char) |char| {
@@ -783,7 +788,7 @@ pub fn computeSdfs() !void {
 
                 const bounds = utils.createBounds(ch_w, ch_h);
                 const padding = font_size * ch_d.*.max_ratio_padding_to_font_size;
-                const sdf_dims = sdf.getSdfTextureDims(bounds, padding);
+                const sdf_dims = sdf_drawing.getSdfTextureDims(bounds, padding);
 
                 ch_d.sdf_scale = sdf_dims.scale;
                 ch_d.max_requested_viewport_font_size = font_size / shared.render_scale;
@@ -825,8 +830,8 @@ pub fn computeSdfs() !void {
 
                 const option_points = try shape.getRelativePoints(allocator);
                 if (option_points) |points| {
-                    const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
-                    const sdf_dims = sdf.getSdfTextureDims(
+                    const sdf_padding = sdf_drawing.getSdfPadding(shape.effects.items);
+                    const sdf_dims = sdf_drawing.getSdfTextureDims(
                         shape.bounds,
                         sdf_padding,
                     );
@@ -861,8 +866,8 @@ pub fn computeSdfs() !void {
 
                     const text_sdf_texture_id = text.getSdfTextureId();
 
-                    const text_padding = sdf.getSdfPadding(text.props.sdf_effects.items);
-                    const sdf_dims = sdf.getSdfTextureDims(
+                    const text_padding = sdf_drawing.getSdfPadding(text.effects.items);
+                    const sdf_dims = sdf_drawing.getSdfTextureDims(
                         text.bounds,
                         text_padding,
                     );
@@ -924,7 +929,7 @@ pub fn updateCache() void {
         switch (asset.value_ptr.*) {
             .img => {},
             .shape => |*shape| {
-                if (shape.props.filter) |filter| {
+                if (shape.props.blur) |blur| {
                     if (!shape.outdated_cache) continue;
 
                     const cache_texture_id: u32 = if (shape.cache_texture_id) |id| id else b: {
@@ -933,8 +938,8 @@ pub fn updateCache() void {
                         break :b id;
                     };
 
-                    const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
-                    const bounds = sdf.getBoundsWithPadding(
+                    const sdf_padding = sdf_drawing.getSdfPadding(shape.effects.items);
+                    const bounds = sdf_drawing.getBoundsWithPadding(
                         shape.bounds,
                         sdf_padding,
                         1 / shared.render_scale,
@@ -944,7 +949,7 @@ pub fn updateCache() void {
                     const size, const sigma, const cache_scale = texture_size.get_safe_blur_dims(
                         init_width,
                         bounds,
-                        filter.gaussianBlur,
+                        blur,
                     );
 
                     if (size.w < consts.MIN_TEXTURE_SIZE or size.h < consts.MIN_TEXTURE_SIZE) continue;
@@ -975,7 +980,7 @@ pub fn updateCache() void {
                         .{ .x = p.x, .y = p.y, .u = 0, .v = 0 },
                     };
 
-                    for (shape.props.sdf_effects.items) |effect| {
+                    for (shape.effects.items) |effect| {
                         web_gpu_programs.draw_shape(
                             &vertex_bounds,
                             shape.getDrawUniform(effect),
@@ -1040,10 +1045,10 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
                 web_gpu_programs.draw_texture(&vertex_data, img.texture_id);
             },
             .shape => |*shape| {
-                const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
+                const sdf_padding = sdf_drawing.getSdfPadding(shape.effects.items);
                 if (shape.cache_texture_id) |cache_texture_id| {
                     web_gpu_programs.draw_texture(
-                        &sdf.getDrawBounds(
+                        &sdf_drawing.getDrawBounds(
                             shape.bounds,
                             sdf_padding,
                             shape.getFilterMargin(),
@@ -1051,9 +1056,9 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
                         cache_texture_id,
                     );
                 } else {
-                    for (shape.props.sdf_effects.items) |effect| {
+                    for (shape.effects.items) |effect| {
                         web_gpu_programs.draw_shape(
-                            &sdf.getDrawBounds(
+                            &sdf_drawing.getDrawBounds(
                                 shape.bounds,
                                 sdf_padding,
                                 shape.getFilterMargin(),
@@ -1074,9 +1079,9 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
                 if (text.typo_props.is_sdf_shared) {
                     const text_sdf_texture_id = text.getSdfTextureId();
 
-                    const padding = sdf.getSdfPadding(text.props.sdf_effects.items);
-                    for (text.props.sdf_effects.items) |effect| {
-                        const text_bounds = sdf.getDrawBounds(
+                    const padding = sdf_drawing.getSdfPadding(text.effects.items);
+                    for (text.effects.items) |effect| {
+                        const text_bounds = sdf_drawing.getDrawBounds(
                             text.bounds,
                             padding,
                             null,
@@ -1103,7 +1108,7 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
                             const ch_d = try fonts.get(text.typo_props.font_family_id, char);
 
                             if (ch_d.sdf_texture_id) |sdf_texture_id| {
-                                for (text.props.sdf_effects.items) |effect| {
+                                for (text.effects.items) |effect| {
                                     const bounds = vertex.getBoundsVertex(text.typo_props.font_size * ch_d.max_ratio_padding_to_font_size, matrix);
                                     const char_sdf_viewport_font_size = ch_d.max_font_size * ch_d.sdf_scale;
                                     const sdf_scale = char_sdf_viewport_font_size / text.typo_props.font_size;
@@ -1174,9 +1179,9 @@ pub fn renderDraw(is_ui_hidden: bool) !void {
         const hover_point_id = state.hovered_asset_id;
 
         if (getSelectedShape()) |shape| {
-            const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
+            const sdf_padding = sdf_drawing.getSdfPadding(shape.effects.items);
             web_gpu_programs.draw_shape(
-                &sdf.getDrawBounds(
+                &sdf_drawing.getDrawBounds(
                     shape.bounds,
                     sdf_padding,
                     null,
@@ -1211,7 +1216,7 @@ pub fn renderPick() !void {
                 web_gpu_programs.pick_texture(&vertex_data, img.texture_id);
             },
             .shape => |shape| {
-                for (shape.props.sdf_effects.items) |effect| {
+                for (shape.effects.items) |effect| {
                     web_gpu_programs.pick_shape(
                         &shape.getPickBounds(),
                         shape.getPickUniform(effect),
@@ -1287,6 +1292,7 @@ pub fn setSnapshot(snapshot: snapshots.ProjectSnapshot, with_snapshot: bool) !vo
                     shape.paths,
                     shape.bounds,
                     shape.props,
+                    shape.effects,
                     shape.sdf_texture_id,
                     shape.cache_texture_id,
                 );
@@ -1297,6 +1303,7 @@ pub fn setSnapshot(snapshot: snapshots.ProjectSnapshot, with_snapshot: bool) !vo
                     text.content orelse "", // should always be provided in real-life executions
                     text.bounds,
                     text.props,
+                    text.effects,
                     text.typo_props,
                     text.sdf_texture_id,
                 );
@@ -1382,7 +1389,7 @@ pub fn setSelectedAssetTypoProps(serialized: typography_props.Serialized, commit
     snapshots.triggerNewSnapshot(true, commit);
 }
 
-pub fn setSelectedAssetProps(serialized_props: asset_props.SerializedProps, commit: bool) !void {
+pub fn setSelectedAssetProps(props: asset_props.Props, serialized_effects: []const sdf_effect.Serialized, commit: bool) !void {
     if (getSelectedAsset()) |asset| {
         switch (asset.*) {
             .img => |img| {
@@ -1390,21 +1397,23 @@ pub fn setSelectedAssetProps(serialized_props: asset_props.SerializedProps, comm
                 // img.props = props;
             },
             .shape => |*shape| {
-                shape.props.deinit();
-                shape.props = try asset_props.deserializeProps(serialized_props, std.heap.page_allocator);
-                if (serialized_props.filter == null and shape.cache_texture_id != null) {
+                shape.props = props;
+                sdf_effect.deinit(shape.effects);
+                shape.effects = try sdf_effect.deserialize(serialized_effects, std.heap.page_allocator);
+                if (props.blur == null and shape.cache_texture_id != null) {
                     // TODO: https://github.com/mateuszJS/magic-render/issues/204
                     // destroy_texture(shape.cache_texture_id);
 
                     shape.cache_texture_id = null;
-                } else if (serialized_props.filter != null and shape.cache_texture_id == null) {
+                } else if (props.blur != null and shape.cache_texture_id == null) {
                     shape.cache_texture_id = create_cache_texture();
                 }
                 shape.outdated_sdf = true;
             },
             .text => |*text| {
-                text.props.deinit();
-                text.props = try asset_props.deserializeProps(serialized_props, std.heap.page_allocator);
+                text.props = props;
+                sdf_effect.deinit(text.effects);
+                text.effects = try sdf_effect.deserialize(serialized_effects, std.heap.page_allocator);
                 if (text.typo_props.is_sdf_shared) {
                     text.is_sdf_outdated = true;
                 }

--- a/src/logic/sdf/drawing.zig
+++ b/src/logic/sdf/drawing.zig
@@ -5,12 +5,7 @@ const fill = @import("fill.zig");
 const std = @import("std");
 const shared = @import("../shared.zig");
 const consts = @import("../consts.zig");
-
-pub const Effect = struct {
-    dist_start: f32,
-    dist_end: f32,
-    fill: fill.Fill,
-};
+const Effect = @import("effect.zig").Effect;
 
 pub const DrawUniform = union(enum) {
     solid: UniformSolid,
@@ -138,11 +133,11 @@ pub fn getDrawUniform(sdf_effect: Effect, sdf_scale: f32, opacity: f32) DrawUnif
     }
 }
 
-pub fn getSdfPadding(sdf_effects: []Effect) f32 {
+pub fn getSdfPadding(effects: []Effect) f32 {
     var padding: f32 = 0.0;
     // because of skeleton render, we cannot od less than zero
 
-    for (sdf_effects) |effect| {
+    for (effects) |effect| {
         if (effect.dist_end > 9999999) {
             std.debug.print("SDF effect dist_end should NOT be a large positive number!\n effect: {any}\n", .{effect});
             @panic("SDF effect dist_end should NOT be a large positive number!");
@@ -157,7 +152,7 @@ pub fn getSdfPadding(sdf_effects: []Effect) f32 {
 }
 
 pub fn getBoundsWithPadding(bounds: [4]PointUV, sdf_padding: f32, scale: f32, filter_margin: ?Point) [4]PointUV {
-    // const sdf_padding = sdf.getSdfPadding(self.props.sdf_effects.items);
+    // const sdf_padding = sdf.getSdfPadding(self.effects.items);
     var padding = Point{
         .x = sdf_padding,
         .y = sdf_padding,

--- a/src/logic/sdf/effect.zig
+++ b/src/logic/sdf/effect.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const sdf_drawing = @import("drawing.zig");
+const fill = @import("fill.zig");
+const types = @import("../types.zig");
+const utils = @import("../utils.zig");
+
+pub const Effect = struct {
+    dist_start: f32,
+    dist_end: f32,
+    fill: fill.Fill,
+};
+
+pub const Serialized = struct {
+    dist_start: f32,
+    dist_end: f32,
+    fill: fill.SerializedFill,
+};
+
+pub fn serialize(effects: std.ArrayList(Effect), allocator: std.mem.Allocator) ![]Serialized {
+    var effects_list = std.ArrayList(Serialized).init(allocator);
+
+    for (effects.items) |effect| {
+        try effects_list.append(Serialized{
+            .dist_start = effect.dist_start,
+            .dist_end = effect.dist_end,
+            .fill = try effect.fill.serialize(allocator),
+        });
+    }
+
+    return try effects_list.toOwnedSlice();
+}
+
+pub fn deinit(effects: std.ArrayList(Effect)) void {
+    for (effects.items) |*effect| {
+        effect.fill.deinit();
+    }
+    effects.deinit();
+}
+
+pub fn compareSerialized(a: []Serialized, b: []Serialized) bool {
+    if (a.len != b.len) return false;
+
+    for (a, b) |effect_a, effect_b| {
+        if (!utils.equalF32(effect_a.dist_start, effect_b.dist_start)) return false;
+        if (!utils.equalF32(effect_a.dist_end, effect_b.dist_end)) return false;
+        if (!effect_a.fill.compare(effect_b.fill)) return false;
+    }
+
+    return true;
+}
+
+// This function cannot be part of SerializedProps struct because it returns []GradientStop(part of props.fill)
+// and there is no writer interface created(only []u8 can be returned as a slices)
+pub fn deserialize(effects: []const Serialized, allocator: std.mem.Allocator) !std.ArrayList(Effect) {
+    var effects_list = std.ArrayList(Effect).init(allocator);
+
+    for (effects) |e| {
+        try effects_list.append(Effect{
+            .dist_start = e.dist_start,
+            .dist_end = e.dist_end,
+            .fill = try fill.Fill.new(e.fill, allocator),
+        });
+    }
+
+    return effects_list;
+}

--- a/src/logic/sdf/effect.zig
+++ b/src/logic/sdf/effect.zig
@@ -1,7 +1,5 @@
 const std = @import("std");
-const sdf_drawing = @import("drawing.zig");
 const fill = @import("fill.zig");
-const types = @import("../types.zig");
 const utils = @import("../utils.zig");
 
 pub const Effect = struct {
@@ -49,8 +47,6 @@ pub fn compareSerialized(a: []const Serialized, b: []const Serialized) bool {
     return true;
 }
 
-// This function cannot be part of SerializedProps struct because it returns []GradientStop(part of props.fill)
-// and there is no writer interface created(only []u8 can be returned as a slices)
 pub fn deserialize(effects: []const Serialized, allocator: std.mem.Allocator) !std.ArrayList(Effect) {
     var effects_list = std.ArrayList(Effect).init(allocator);
 

--- a/src/logic/sdf/effect.zig
+++ b/src/logic/sdf/effect.zig
@@ -37,7 +37,7 @@ pub fn deinit(effects: std.ArrayList(Effect)) void {
     effects.deinit();
 }
 
-pub fn compareSerialized(a: []Serialized, b: []Serialized) bool {
+pub fn compareSerialized(a: []const Serialized, b: []const Serialized) bool {
     if (a.len != b.len) return false;
 
     for (a, b) |effect_a, effect_b| {

--- a/src/logic/sdf/fill.zig
+++ b/src/logic/sdf/fill.zig
@@ -180,7 +180,7 @@ pub const Fill = union(enum) {
                         .start = g.start,
                         .end = g.end,
                         .radius_ratio = g.radius_ratio,
-                        .stops = g.stops.items,
+                        .stops = try allocator.dupe(GradientStop, g.stops.items),
                     },
                 };
             },

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -13,9 +13,10 @@ const Matrix3x3 = @import("../matrix.zig").Matrix3x3;
 const consts = @import("../consts.zig");
 const path_utils = @import("path_utils.zig");
 const fill = @import("../sdf/fill.zig");
-const sdf = @import("../sdf/sdf.zig");
+const sdf_drawing = @import("../sdf/drawing.zig");
 const AssetId = @import("../asset_id.zig").AssetId;
 const asset_props = @import("../asset_props.zig");
+const sdf_effect = @import("../sdf/effect.zig");
 
 const CREATE_HANDLE_THRESHOLD = 10.0;
 // above this distance two handles are created around control point
@@ -49,6 +50,7 @@ pub const Shape = struct {
     id: u32,
     paths: std.ArrayList(Path),
     props: asset_props.Props,
+    effects: std.ArrayList(sdf_effect.Effect),
     bounds: [4]PointUV,
 
     sdf_scale: f32 = 1.0,
@@ -71,7 +73,8 @@ pub const Shape = struct {
         id: u32,
         input_paths: []const []const Point,
         input_bounds: [4]PointUV,
-        input_props: asset_props.SerializedProps,
+        props: asset_props.Props,
+        input_effects: []const sdf_effect.Serialized,
         sdf_texture_id: u32,
         cache_texture_id: ?u32,
         allocator: std.mem.Allocator,
@@ -89,7 +92,8 @@ pub const Shape = struct {
         var shape = Shape{
             .id = id,
             .paths = paths_list,
-            .props = try asset_props.deserializeProps(input_props, allocator),
+            .props = props,
+            .effects = try sdf_effect.deserialize(input_effects, allocator),
             .sdf_texture_id = sdf_texture_id,
             .outdated_sdf = true,
             .should_update_sdf = false,
@@ -276,9 +280,9 @@ pub const Shape = struct {
         return skeleton_buffer.toOwnedSlice();
     }
 
-    pub fn getSkeletonUniform(self: Shape) sdf.DrawUniform {
+    pub fn getSkeletonUniform(self: Shape) sdf_drawing.DrawUniform {
         const stroke_width = path_utils.SKELETON_LINE_WIDTH * self.sdf_scale * shared.render_scale;
-        return sdf.DrawUniform{
+        return sdf_drawing.DrawUniform{
             .solid = .{
                 .dist_start = stroke_width * 0.5,
                 .dist_end = -stroke_width * 0.5,
@@ -329,16 +333,16 @@ pub const Shape = struct {
         return points.toOwnedSlice();
     }
 
-    pub fn getPickUniform(self: Shape, sdf_effect: sdf.Effect) PickUniform {
+    pub fn getPickUniform(self: Shape, effect: sdf_effect.Effect) PickUniform {
         return PickUniform{
-            .dist_start = sdf_effect.dist_start * self.sdf_scale,
-            .dist_end = sdf_effect.dist_end * self.sdf_scale,
+            .dist_start = effect.dist_start * self.sdf_scale,
+            .dist_end = effect.dist_end * self.sdf_scale,
         };
     }
 
-    pub fn getDrawUniform(self: Shape, sdf_effect: sdf.Effect) sdf.DrawUniform {
-        return sdf.getDrawUniform(
-            sdf_effect,
+    pub fn getDrawUniform(self: Shape, effect: sdf_effect.Effect) sdf_drawing.DrawUniform {
+        return sdf_drawing.getDrawUniform(
+            effect,
             self.sdf_scale,
             self.props.opacity,
         );
@@ -374,7 +378,7 @@ pub const Shape = struct {
             self.bounds[0].distance(self.bounds[3]),
         );
 
-        const padding = sdf.getSdfPadding(self.props.sdf_effects.items);
+        const padding = sdf_drawing.getSdfPadding(self.effects.items);
         for (points) |*point| {
             const scaled = scale.get(point);
             point.x = padding + scaled.x;
@@ -385,8 +389,8 @@ pub const Shape = struct {
     }
 
     pub fn getPickBounds(self: Shape) [6]images.PickVertex {
-        const sdf_padding = sdf.getSdfPadding(self.props.sdf_effects.items);
-        const bounds = sdf.getDrawBounds(self.bounds, sdf_padding, null);
+        const sdf_padding = sdf_drawing.getSdfPadding(self.effects.items);
+        const bounds = sdf_drawing.getDrawBounds(self.bounds, sdf_padding, null);
         var buffer: [6]images.PickVertex = undefined;
         for (bounds, 0..) |b, i| {
             buffer[i] = .{
@@ -398,9 +402,9 @@ pub const Shape = struct {
     }
 
     pub fn getFilterMargin(self: Shape) Point {
-        return if (self.props.filter) |filter| Point{
-            .x = 3 * filter.gaussianBlur.x,
-            .y = 3 * filter.gaussianBlur.y,
+        return if (self.props.blur) |blur| Point{
+            .x = 3 * blur.x,
+            .y = 3 * blur.y,
         } else consts.POINT_ZERO;
     }
 
@@ -414,8 +418,9 @@ pub const Shape = struct {
         return Serialized{
             .id = self.id,
             .paths = try paths_list.toOwnedSlice(),
-            .props = try self.props.serialize(allocator),
             .bounds = self.bounds,
+            .props = self.props,
+            .effects = try sdf_effect.serialize(self.effects, allocator),
             .sdf_texture_id = self.sdf_texture_id,
             .cache_texture_id = self.cache_texture_id,
         };
@@ -426,11 +431,7 @@ pub const Shape = struct {
             path.deinit();
         }
         self.paths.deinit();
-
-        for (self.props.sdf_effects.items) |*effect| {
-            effect.fill.deinit();
-        }
-        self.props.sdf_effects.deinit();
+        sdf_effect.deinit(self.effects);
     }
 };
 
@@ -442,8 +443,9 @@ pub const PickUniform = struct {
 pub const Serialized = struct {
     id: u32,
     paths: []const []const Point,
-    props: asset_props.SerializedProps,
     bounds: [4]PointUV,
+    props: asset_props.Props,
+    effects: []sdf_effect.Serialized,
     sdf_texture_id: u32,
     cache_texture_id: ?u32,
 
@@ -460,6 +462,7 @@ pub const Serialized = struct {
         const all_match = self.id == other.id and
             self.paths.len == other.paths.len and
             self.props.compare(other.props) and
+            sdf_effect.compareSerialized(self.effects, other.effects) and
             utils.compareBounds(self.bounds, other.bounds);
 
         if (!all_match) {

--- a/src/logic/shapes/shapes.zig
+++ b/src/logic/shapes/shapes.zig
@@ -445,7 +445,7 @@ pub const Serialized = struct {
     paths: []const []const Point,
     bounds: [4]PointUV,
     props: asset_props.Props,
-    effects: []sdf_effect.Serialized,
+    effects: []const sdf_effect.Serialized,
     sdf_texture_id: u32,
     cache_texture_id: ?u32,
 

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -10,11 +10,12 @@ const rects = @import("../rects.zig");
 const shared = @import("../shared.zig");
 const lines = @import("../lines.zig");
 const Matrix3x3 = @import("../matrix.zig").Matrix3x3;
-const sdf = @import("../sdf/sdf.zig");
+const sdf_drawing = @import("../sdf/drawing.zig");
 const asset_props = @import("../asset_props.zig");
 const fill = @import("../sdf/fill.zig");
 const typography_props = @import("typography_props.zig");
 const js_glue = @import("../js_glue.zig");
+const sdf_effect = @import("../sdf/effect.zig");
 
 const ENTER_CHAR_CODE: u21 = 0xa;
 const SOFT_BREAK_MARKER: u21 = 0x2060;
@@ -65,6 +66,7 @@ pub const Text = struct {
     is_sdf_outdated: bool = true,
 
     props: asset_props.Props,
+    effects: std.ArrayList(sdf_effect.Effect),
     typo_props: typography_props.Props,
 
     pub fn new(
@@ -72,7 +74,8 @@ pub const Text = struct {
         id: u32,
         content: []const u8,
         bounds: [4]PointUV,
-        input_props: asset_props.SerializedProps,
+        props: asset_props.Props,
+        input_effects: []const sdf_effect.Serialized,
         input_typo_props: typography_props.Serialized,
         sdf_texture_id: ?u32,
     ) !Text {
@@ -82,7 +85,8 @@ pub const Text = struct {
             .typo_props = typography_props.deserialize(input_typo_props),
             .bounds = bounds,
             .text_vertex = std.ArrayList(CharVertex).init(allocator),
-            .props = try asset_props.deserializeProps(input_props, allocator),
+            .props = props,
+            .effects = try sdf_effect.deserialize(input_effects, allocator),
             .sdf_texture_id = sdf_texture_id,
         };
 
@@ -405,35 +409,30 @@ pub const Text = struct {
         return triangles_buffer.toOwnedSlice();
     }
 
-    pub fn getDrawUniform(self: Text, sdf_effect: sdf.Effect, sdf_scale: f32) sdf.DrawUniform {
-        return sdf.getDrawUniform(
-            sdf_effect,
+    pub fn getDrawUniform(self: Text, effects: sdf_effect.Effect, sdf_scale: f32) sdf_drawing.DrawUniform {
+        return sdf_drawing.getDrawUniform(
+            effects,
             sdf_scale,
             self.props.opacity,
         );
     }
 
     pub fn serialize(self: Text, allocator: std.mem.Allocator) !Serialized {
-        var effects_list = std.ArrayList(asset_props.SerializedSdfEffect).init(allocator);
-        for (self.props.sdf_effects.items) |effect| {
-            try effects_list.append(asset_props.SerializedSdfEffect{
+        var effects_list = std.ArrayList(sdf_effect.Serialized).init(allocator);
+        for (self.effects.items) |effect| {
+            try effects_list.append(sdf_effect.Serialized{
                 .dist_start = effect.dist_start,
                 .dist_end = effect.dist_end,
                 .fill = try effect.fill.serialize(allocator),
             });
         }
 
-        const props = asset_props.SerializedProps{
-            .sdf_effects = try effects_list.toOwnedSlice(),
-            .filter = self.props.filter,
-            .opacity = self.props.opacity,
-        };
-
         return Serialized{
             .id = self.id,
             .content = self.content,
             .bounds = self.bounds,
-            .props = props,
+            .props = self.props,
+            .effects = try effects_list.toOwnedSlice(),
             .typo_props = self.typo_props.serialize(),
             .sdf_texture_id = self.sdf_texture_id,
         };
@@ -445,7 +444,8 @@ pub const Serialized = struct {
     content: ?[]const u8, // it's a null pointer exception for case when content is empty, we allow null
     // to avoid throwing the exception by Zigar
     bounds: [4]PointUV,
-    props: asset_props.SerializedProps,
+    props: asset_props.Props,
+    effects: []sdf_effect.Serialized,
     typo_props: typography_props.Serialized,
     sdf_texture_id: ?u32,
 
@@ -454,6 +454,7 @@ pub const Serialized = struct {
             self.props.compare(other.props) and
             utils.compareBounds(self.bounds, other.bounds) and
             self.typo_props.compare(other.typo_props) and
+            sdf_effect.compareSerialized(self.effects, other.effects) and
             std.mem.eql(u8, self.content orelse &.{}, other.content orelse &.{});
 
         return all_match;

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -437,6 +437,12 @@ pub const Text = struct {
             .sdf_texture_id = self.sdf_texture_id,
         };
     }
+
+    pub fn deinit(self: *Text) void {
+        std.heap.page_allocator.free(self.content);
+        self.text_vertex.deinit();
+        sdf_effect.deinit(self.effects);
+    }
 };
 
 pub const Serialized = struct {

--- a/src/logic/ui.zig
+++ b/src/logic/ui.zig
@@ -4,7 +4,7 @@ const asset_props = @import("asset_props.zig");
 const texture_size = @import("texture_size.zig");
 const Point = @import("types.zig").Point;
 const PointUV = @import("types.zig").PointUV;
-const sdf = @import("sdf/sdf.zig");
+const sdf_drawing = @import("sdf/drawing.zig");
 const consts = @import("consts.zig");
 const INFINITE_DISTANCE = @import("index.zig").INFINITE_DISTANCE;
 
@@ -19,12 +19,13 @@ pub fn importUiElement(
     paths: []const []const Point,
     sdf_texture_id: u32,
 ) !void {
-    const props = asset_props.SerializedProps{};
+    const props = asset_props.Props{};
     const shape = try shapes.Shape.new(
         0,
         paths,
         consts.DEFAULT_BOUNDS,
         props,
+        &.{},
         sdf_texture_id,
         0,
         std.heap.page_allocator,
@@ -42,8 +43,8 @@ pub fn generateUiElementsSdf(compute_shape: *const fn ([]const Point, u32, u32, 
         var shape = entry.value_ptr;
         const option_points = try shape.getRelativePoints(allocator);
         if (option_points) |points| {
-            const sdf_padding = sdf.getSdfPadding(shape.props.sdf_effects.items);
-            const bounds = sdf.getBoundsWithPadding(
+            const sdf_padding = sdf_drawing.getSdfPadding(shape.effects.items);
+            const bounds = sdf_drawing.getBoundsWithPadding(
                 shape.bounds,
                 sdf_padding,
                 1,
@@ -76,11 +77,11 @@ pub const DrawVertex = struct {
 
 pub fn draw(
     dataset: []DrawVertex,
-    draw_shape: *const fn ([]const PointUV, sdf.DrawUniform, u32) void,
+    draw_shape: *const fn ([]const PointUV, sdf_drawing.DrawUniform, u32) void,
 ) !void {
     for (dataset) |data| {
         if (elements.get(@intFromEnum(data.icon))) |shape| {
-            const uniform = sdf.DrawUniform{
+            const uniform = sdf_drawing.DrawUniform{
                 .solid = .{
                     .dist_start = INFINITE_DISTANCE,
                     .dist_end = 0,

--- a/src/snapshots/convert.ts
+++ b/src/snapshots/convert.ts
@@ -1,5 +1,5 @@
 import { toFill, toZigFill } from 'snapshots/fill'
-import { PointUV, ShapeProps, TypoProps, ZigShapeProps } from 'types'
+import { Effect, PointUV, ShapeProps, TypoProps, ZigEffect, ZigShapeProps } from 'types'
 
 export function toBounds(bounds: PointUV[]): PointUV[] {
   return bounds.map((point) => ({
@@ -10,19 +10,28 @@ export function toBounds(bounds: PointUV[]): PointUV[] {
   }))
 }
 
+export function toEffects(effects: ZigEffect[]): Effect[] {
+  return [...effects].map((effect) => ({
+    dist_start: effect.dist_start,
+    dist_end: effect.dist_end,
+    fill: toFill(effect.fill),
+  }))
+}
+
+export function toZigEffects(effects: Effect[]): ZigEffect[] {
+  return effects.map((effect) => ({
+    dist_start: effect.dist_start,
+    dist_end: effect.dist_end,
+    fill: toZigFill(effect.fill),
+  }))
+}
+
 export function toShapeProps(props: ZigShapeProps): ShapeProps {
   return {
-    sdf_effects: [...props.sdf_effects].map((effect) => ({
-      dist_start: effect.dist_start,
-      dist_end: effect.dist_end,
-      fill: toFill(effect.fill),
-    })),
-    filter: props.filter?.gaussianBlur
+    blur: props.blur
       ? {
-          gaussianBlur: {
-            x: props.filter.gaussianBlur.x,
-            y: props.filter.gaussianBlur.y,
-          },
+          x: props.blur.x,
+          y: props.blur.y,
         }
       : null,
     opacity: props.opacity,
@@ -40,17 +49,10 @@ export function toTypoProps(props: TypoProps): TypoProps {
 
 export function toZigShapeProps(props: ShapeProps): ZigShapeProps {
   return {
-    sdf_effects: [...props.sdf_effects].map((effect) => ({
-      dist_start: effect.dist_start,
-      dist_end: effect.dist_end,
-      fill: toZigFill(effect.fill),
-    })),
-    filter: props.filter?.gaussianBlur
+    blur: props.blur
       ? {
-          gaussianBlur: {
-            x: props.filter.gaussianBlur.x,
-            y: props.filter.gaussianBlur.y,
-          },
+          x: props.blur.x,
+          y: props.blur.y,
         }
       : null,
     opacity: props.opacity,

--- a/src/snapshots/snapshots.ts
+++ b/src/snapshots/snapshots.ts
@@ -1,5 +1,5 @@
 import { Asset, ProjectSnapshot, ZigProjectSnapshot } from 'types'
-import { toBounds, toShapeProps, toTypoProps } from './convert'
+import { toBounds, toEffects, toShapeProps, toTypoProps } from './convert'
 import * as Typing from 'typing'
 import * as Textures from 'textures'
 import * as Fonts from 'fonts'
@@ -49,6 +49,7 @@ export function saveSnapshot(snapshot: ZigProjectSnapshot) {
         ),
         bounds: toBounds([...shape.bounds]),
         props: toShapeProps(shape.props),
+        effects: toEffects(shape.effects),
         sdf_texture_id: shape.sdf_texture_id,
         cache_texture_id: shape.cache_texture_id,
       }
@@ -63,6 +64,7 @@ export function saveSnapshot(snapshot: ZigProjectSnapshot) {
         bounds: toBounds([...asset.text.bounds]),
         typo_props: toTypoProps(asset.text.typo_props),
         props: toShapeProps(asset.text.props),
+        effects: toEffects(asset.text.effects),
         sdf_texture_id: asset.text.sdf_texture_id,
       }
     } else {

--- a/src/snapshots/toZigAsset.ts
+++ b/src/snapshots/toZigAsset.ts
@@ -1,5 +1,5 @@
 import { Asset, ZigAsset } from 'types'
-import { toZigShapeProps } from './convert'
+import { toZigEffects, toZigShapeProps } from './convert'
 import { NO_ASSET_ID } from 'consts'
 import * as Textures from 'textures'
 
@@ -10,8 +10,9 @@ export default function toZigAsset(asset: Asset): ZigAsset {
       shape: {
         id: asset.id || NO_ASSET_ID,
         paths: asset.paths,
-        props: toZigShapeProps(asset.props),
         bounds: asset.bounds,
+        props: toZigShapeProps(asset.props),
+        effects: toZigEffects(asset.effects),
         sdf_texture_id: asset.sdf_texture_id || Textures.createSDF(),
         cache_texture_id: asset.cache_texture_id || null,
       },
@@ -24,6 +25,7 @@ export default function toZigAsset(asset: Asset): ZigAsset {
         bounds: asset.bounds,
         typo_props: asset.typo_props,
         props: toZigShapeProps(asset.props),
+        effects: toZigEffects(asset.effects),
         sdf_texture_id: asset.sdf_texture_id,
       },
     }

--- a/src/svgToShapes/collectShapesData.ts
+++ b/src/svgToShapes/collectShapesData.ts
@@ -11,11 +11,12 @@ import {
 import * as radialGradient from './radialGradient'
 import { Def, Defs, DefStop } from './definitions'
 import getProps from './getProps'
-import { Point, SdfEffect, ShapeProps } from 'types'
+import { Point, Fill, Effect, ShapeProps } from 'types'
 
 export interface ShapeData {
   paths: Point[][]
   props: ShapeProps
+  effects: Effect[]
   boundingBox: BoundingBox
 }
 
@@ -28,11 +29,7 @@ function applyLinearTransform(x: number, y: number, m: number[]): Point {
 }
 
 // Convert stops (apply opacity) and bake transform. Here we assume gradientUnits=userSpaceOnUse.
-function toRuntimeGradient(
-  def: Def,
-  boundingBox: BoundingBox,
-  overrideAlpha = 1
-): SdfEffect['fill'] | null {
+function toRuntimeGradient(def: Def, boundingBox: BoundingBox, overrideAlpha = 1): Fill | null {
   if (def.type !== 'linear-gradient' && def.type !== 'radial-gradient') {
     console.error('toRuntimeGradient receive definition which is not a gradient!')
     return null
@@ -163,16 +160,17 @@ export default function collectShapesData(
       const boundingBox = getBoundingBox(paths)
 
       const serializedProps: ShapeProps = {
-        sdf_effects: [],
-        filter: null,
+        blur: null,
         opacity: 1,
       }
+      const serializedEffects = []
+
       // fill/stroke: color or url(#id)
       if (props.fill) {
         const fillOpacity = getNum(props['fill-opacity'], 1)
         const fill = String(props.fill)
         const m = fill.match(/^url\(#([^)]+)\)$/)
-        let serializedFill: SdfEffect['fill'] | null = null
+        let serializedFill: Fill | null = null
 
         if (m) {
           const def = defs[m[1]]
@@ -188,7 +186,7 @@ export default function collectShapesData(
         }
 
         if (serializedFill) {
-          serializedProps.sdf_effects.push({
+          serializedEffects.push({
             dist_start: Number.MAX_SAFE_INTEGER,
             dist_end: 0,
             fill: serializedFill,
@@ -200,7 +198,7 @@ export default function collectShapesData(
         const color = String(props.stroke) || '#000'
         const width = getNum(props['stroke-width'], 1)
         const m = color.match(/^url\(#([^)]+)\)$/)
-        let serializedFill: SdfEffect['fill'] | null = null
+        let serializedFill: Fill | null = null
 
         if (m) {
           const def = defs[m[1]]
@@ -216,7 +214,7 @@ export default function collectShapesData(
         }
 
         if (serializedFill) {
-          serializedProps.sdf_effects.push({
+          serializedEffects.push({
             dist_start: width / 2,
             dist_end: -width / 2,
             fill: serializedFill,
@@ -231,11 +229,9 @@ export default function collectShapesData(
         if (m) {
           const def = defs[m[1]]
           if (def?.stdDeviation) {
-            serializedProps.filter = {
-              gaussianBlur: {
-                x: def.stdDeviation[0],
-                y: def.stdDeviation[1],
-              },
+            serializedProps.blur = {
+              x: def.stdDeviation[0],
+              y: def.stdDeviation[1],
             }
           }
         }
@@ -258,6 +254,7 @@ export default function collectShapesData(
       shapes.push({
         paths: transformedPaths,
         props: serializedProps,
+        effects: serializedEffects,
         boundingBox,
       })
     }

--- a/src/svgToShapes/getShapesAssets.ts
+++ b/src/svgToShapes/getShapesAssets.ts
@@ -21,7 +21,7 @@ export default function getShapesZigAssets(shapesData: ShapeData[], maxY?: numbe
     maxY = totalBB.max_y
   }
 
-  return shapesData.map(({ paths, props }) => {
+  return shapesData.map(({ paths, props, effects }) => {
     const correctedPaths = paths.map((path) => path.map((p) => ({ x: p.x, y: maxY - p.y })))
 
     return {
@@ -29,6 +29,7 @@ export default function getShapesZigAssets(shapesData: ShapeData[], maxY?: numbe
       paths: correctedPaths,
       bounds: DEFAULT_BOUNDS,
       props,
+      effects,
       sdf_texture_id: Textures.createSDF(),
       cache_texture_id: null,
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,15 +51,14 @@ export type Fill =
   | { solid: Color }
   | { program: Program }
 
-export type SdfEffect = {
+export type Effect = {
   dist_start: number
   dist_end: number
   fill: Fill
 }
 
 export type ShapeProps = {
-  sdf_effects: SdfEffect[]
-  filter: { gaussianBlur: Point } | null
+  blur: Point | null
   opacity: number
 }
 
@@ -82,8 +81,9 @@ export type Image = {
 export type Shape = {
   id?: number // not needed while loading project but useful for undo/redo to maintain selection
   paths: Point[][]
-  props: ShapeProps
   bounds: PointUV[]
+  props: ShapeProps
+  effects: Effect[]
   sdf_texture_id?: number
   cache_texture_id?: number | null
 }
@@ -93,6 +93,7 @@ export type Text = {
   content: string
   bounds: PointUV[]
   props: ShapeProps
+  effects: Effect[]
   typo_props: TypoProps
   sdf_texture_id: number | null
 }
@@ -121,15 +122,14 @@ export type ZigFill = OneOf<{
   program_id: number
 }>
 
-export type ZigSdfEffect = {
+export type ZigEffect = {
   dist_start: number
   dist_end: number
   fill: ZigFill
 }
 
 export type ZigShapeProps = {
-  sdf_effects: ZigSdfEffect[]
-  filter: { gaussianBlur: Point } | null
+  blur: Point | null
   opacity: number
 }
 
@@ -142,8 +142,9 @@ type ZigImage = {
 type ZigShape = {
   id: number
   paths: Point[][]
-  props: ZigShapeProps
   bounds: PointUV[]
+  props: ZigShapeProps
+  effects: ZigEffect[]
   sdf_texture_id: number
   cache_texture_id: number | null
 }
@@ -153,6 +154,7 @@ type ZigText = {
   content: string | null
   bounds: PointUV[]
   props: ZigShapeProps
+  effects: ZigEffect[]
   typo_props: TypoProps
   sdf_texture_id: number | null
 }
@@ -181,7 +183,7 @@ export type CreatorAPI = {
   setTool: (tool: CreatorTool) => void
   // we need to obtain live update!
   updateAssetTypoProps: (props: TypoProps, commit: boolean) => void // updates typography properties of selected asset
-  updateAssetProps: (props: ShapeProps, commit: boolean) => void // updates properties of selected asset
+  updateAssetProps: (props: ShapeProps, effects: Effect[], commit: boolean) => void // updates properties of selected asset
   updateAssetBounds: (bounds: PointUV[], commit: boolean) => void // updates bounds of selected asset
   INFINITE_DISTANCE_THRESHOLD: number // threshold value for considering a distance as "infinite" in SDF fill effects
   INFINITE_DISTANCE: number // maximum f32 value, used for SDF fill effects


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Effects separated from asset properties: shapes and text now carry an explicit effects array.
  * Blur handling simplified: direct blur values replace prior filter-based representation.
  * Asset update API expanded to accept effects alongside properties and commit flag.

* **New Features**
  * Snapshots, export/import flows now include effects to preserve gradients/strokes.
  * Conversion utilities added to translate effects between runtime and internal formats.

* **Bug Fix**
  * Radial gradient stop data now duplicated during serialization to avoid ownership issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->