### PR TITLE
fix: restruct and rename all js gluecode

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,19 +1,6 @@
-import type * as types from './src/types'
+export {}
 
 declare global {
-  /* expose types globally to make the available in *.zig ambient declaration.
-  Import & exports in ambient declaration are forbidden.
-  Also these types are needed to be exported from the package.
-  Otherwise if those are needed only internally, we could move them to ./src/logic/index.d.ts */
-  namespace zig {
-    type Point = types.Point
-    type PointUV = types.PointUV
-    type BoundingBox = types.BoundingBox
-    type Id = types.Id
-    type ShapeProps = types.ShapeProps
-    type ZigAsset = types.ZigAsset
-  }
-
   type OneOf<T> = {
     [K in keyof T]: { [P in K]: T[P] } & { [P in Exclude<keyof T, K>]: null }
   }[keyof T]

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,18 @@ import throttle from 'utils/throttle'
 import generatePreview from 'WebGPU/generatePreview'
 import * as Typing from 'typing'
 import * as Fonts from 'fonts'
-import { Asset, CreatorAPI, CreatorTool, Id, ProjectSnapshot, ZigAsset } from './types'
+import {
+  Asset,
+  CreatorAPI,
+  CreatorTool,
+  Id,
+  ProjectSnapshot,
+  ZigAsset,
+  ZigProjectSnapshot,
+} from './types'
 import { destroyCanvasTextures } from 'getCanvasRenderDescriptor'
 import setCamera from 'utils/setCamera'
-import { toZigEffects, toZigShapeProps } from 'snapshots/convert'
+import { toZigEffects } from 'snapshots/convert'
 import * as CustomPrograms from 'customPrograms'
 import * as Snapshots from 'snapshots/snapshots'
 import toZigAsset from 'snapshots/toZigAsset'
@@ -142,10 +150,20 @@ export default async function initCreator(
     }
   }
 
-  Logic.connectOnAssetUpdateCallback((snapshot, commit) => {
+  const onAssetUpdate = (snapshot: ZigProjectSnapshot, commit: boolean) => {
     Snapshots.saveSnapshot(snapshot)
     newAssetsSnapshot(commit)
-  })
+  }
+
+  Logic.glueJsGeneral(
+    onAssetUpdate,
+    (id) => onAssetSelect([...id] as Id),
+    onUpdateTool,
+    Textures.createSDF,
+    Textures.createComputeDepthTexture,
+    Fonts.getCharData,
+    Fonts.getKerning
+  )
 
   function newAssetsSnapshot(commit: boolean) {
     // this function is not part of Logic.connect_on_asset_update_callback
@@ -156,17 +174,7 @@ export default async function initCreator(
     }
   }
 
-  Logic.connectOnAssetSelectionCallback((id) => onAssetSelect([...id] as Id))
-  Logic.connectCreateSdfTexture(Textures.createSDF, Textures.createComputeDepthTexture)
-  Logic.connectTyping(
-    Typing.enable,
-    Typing.disable,
-    Typing.updateContent,
-    Typing.updateSelection,
-    Fonts.getCharData,
-    Fonts.getKerning
-  )
-  Logic.onUpdateToolCallback(onUpdateTool)
+  Logic.connectTyping(Typing.enable, Typing.disable, Typing.updateContent, Typing.updateSelection)
 
   const addImages: CreatorAPI['addImages'] = async (urls) => {
     const results = await Promise.allSettled(
@@ -261,7 +269,7 @@ export default async function initCreator(
       Logic.setTool(tool)
     },
     updateAssetProps: (props, effects, commit) => {
-      Logic.setSelectedAssetProps(toZigShapeProps(props), toZigEffects(effects), commit)
+      Logic.setSelectedAssetProps(props, toZigEffects(effects), commit)
     },
     updateAssetBounds: Logic.setSelectedAssetBounds,
     updateAssetTypoProps: (typoProps, commit) => {

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -16,7 +16,16 @@ type ShapeDrawUniform = OneOf<{
 }>
 
 declare module '*.zig' {
-  import { ZigProjectSnapshot, TypoProps, ZigShapeProps, ZigEffect } from 'types'
+  import {
+    Point,
+    PointUV,
+    Id,
+    ZigProjectSnapshot,
+    TypoProps,
+    BasicProps,
+    ZigEffect,
+    BoundingBox,
+  } from 'types'
 
   export const initState: (
     width: number,
@@ -25,23 +34,14 @@ declare module '*.zig' {
     max_buffer_size: number
   ) => void
   export const updateCache: VoidFunction
-  export const addShape: (
-    maybe_asset_id: number,
-    paths: zig.Point[][],
-    bounds: zig.PointUV[] | null,
-    props: Partial<zig.ShapeProps>,
-    sdf_texture_id: number,
-    cache_texture_id: null | number
-  ) => number /* id */
   export const removeAsset: () => void
   export const setSnapshot: (snapshot: ZigProjectSnapshot, with_snapshot: boolean) => void
 
-  export const onUpdatePick: (id: zig.Id) => void
+  export const onUpdatePick: (id: Id) => void
   export const onPointerDown: (x: number, y: number) => void
   export const onPointerUp: () => void
   export const onPointerMove: (x: number, y: number) => void
   export const onPointerDoubleClick: VoidFunction
-  export const onUpdateToolCallback: (cb: (new_tool: number) => void) => void
   export const onPointerLeave: VoidFunction
   export const commitChanges: VoidFunction
   export const updateRenderScale: (render_scale: number) => void
@@ -62,7 +62,7 @@ declare module '*.zig' {
     width: number
     height: number
     sdf_texture_id: number | null
-    setPaths(paths: zig.Point[]): void // we have to call std.mem.Allocator.dupe() to allocate permament memory in zig
+    setPaths(paths: Point[]): void // we have to call std.mem.Allocator.dupe() to allocate permament memory in zig
   }
 
   export const SerializedCharDetails: new ({
@@ -79,9 +79,9 @@ declare module '*.zig' {
     sdf_texture_id: number | null
   }) => SerializedCharDetails
 
-  export const Point: new ({ x, y }: { x: number; y: number }) => zig.Point
+  export const Point: new ({ x, y }: { x: number; y: number }) => Point
 
-  export const PtrI32: new (p: zig.Point[][]) => zig.Point[][]
+  export const PtrI32: new (p: Point[][]) => Point[][]
 
   export const connectWebGpuPrograms: (programs: {
     draw_texture: (vertex_data: PointerDataView, texture_id: number) => void
@@ -125,26 +125,27 @@ declare module '*.zig' {
       sdf_texture_id: number
     ) => void
   }) => void
-  export const connectOnAssetUpdateCallback: (
-    cb: (snapshot: ZigProjectSnapshot, commit: boolean) => void
-  ) => void
-  export const connectOnAssetSelectionCallback: (cb: (data: zig.Id) => void) => void
-  export const connectCreateSdfTexture: (
+  export function glueJsGeneral(
+    onAssetUpdate: (snapshot: ZigProjectSnapshot, commit: boolean) => void,
+    onAssetSelection: (data: Id) => void,
+    onUpdateTool: (new_tool: number) => void,
     createSdfTexture: () => number,
-    createComputeDepthTexture: (width: number, height: number) => number
-  ) => void
-  export const connectCacheCallbacks: (
-    create_cache_texture: () => number,
-    start_cache: (texture_id: number, box: zig.BoundingBox, width: number, height: number) => void,
-    end_cache: VoidFunction
-  ) => void
+    createComputeDepthTexture: (width: number, height: number) => number,
+    getCharData: (font_id: number, char_code: number) => SerializedCharDetails,
+    getKerning: (font_id: number, char_code_a: number, char_code_b: number) => number
+  ): void
+
+  export function glueJsTextureCache(
+    createCacheTexture: () => number,
+    startCache: (texture_id: number, box: BoundingBox, width: number, height: number) => void,
+    endCache: VoidFunction
+  ): void
+
   export const connectTyping: (
     enable: (text: string) => void,
     disable: VoidFunction,
     updateContent: (text: string) => void,
-    updateSelection: (start: number, end: number) => void,
-    getCharData: (font_id: number, char_code: number) => SerializedCharDetails,
-    getKerning: (font_id: number, char_code_a: number, char_code_b: number) => number
+    updateSelection: (start: number, end: number) => void
   ) => void
   export const setCaretPosition: (selection_start: number, selection_end: number) => void
 
@@ -157,17 +158,17 @@ declare module '*.zig' {
 
   export const importUiElement: (
     id: UiElementType,
-    paths: zig.Point[][],
+    paths: Point[][],
     sdf_texture_id: number
   ) => void
   export const generateUiElementsSdf: VoidFunction
 
   export const setSelectedAssetProps: (
-    props: ZigShapeProps,
+    props: BasicProps,
     effects: ZigEffect[],
     commit: boolean
   ) => void
-  export const setSelectedAssetBounds: (bounds: zig.PointUV[], commit: boolean) => void
+  export const setSelectedAssetBounds: (bounds: PointUV[], commit: boolean) => void
   export const setSelectedAssetTypoProps: (typo_props: TypoProps, commit: boolean) => void
 
   export const addFont: (font_id: number) => void

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -62,20 +62,22 @@ pub fn connectWebGpuPrograms(programs: *const WebGpuPrograms) void {
     web_gpu_programs = programs; // orelse WebGpuPrograms{};
 }
 
-pub fn connectOnAssetUpdateCallback(cb: *const fn (snapshots.ProjectSnapshot, bool) void) void {
-    snapshots.passSnapshot = cb;
-}
-
-var on_asset_select_cb: *const fn ([4]u32) void = undefined;
-pub fn connectOnAssetSelectionCallback(cb: *const fn ([4]u32) void) void {
-    on_asset_select_cb = cb;
-}
-
-pub const connectCreateSdfTexture = js_glue.connectCreateSdfTexture;
-
-var on_update_tool: *const fn (u16) void = undefined;
-pub fn onUpdateToolCallback(cb: *const fn (u16) void) void {
-    on_update_tool = cb;
+pub fn glueJsGeneral(
+    onAssetUpdate: *const fn (snapshots.ProjectSnapshot, bool) void,
+    onAssetSelection: *const fn ([4]u32) void,
+    onUpdateTool: *const fn (u16) void,
+    createSdfTexture: *const fn () u32,
+    createComputeDepthTexture: *const fn (u32, u32) u32,
+    getCharData: *const fn (u32, u21) SerializedCharDetails,
+    getKerning: *const fn (u32, u21, u21) f32,
+) void {
+    snapshots.passSnapshot = onAssetUpdate;
+    js_glue.onAssetSelection = onAssetSelection;
+    js_glue.onUpdateTool = onUpdateTool;
+    js_glue.createSdfTexture = createSdfTexture;
+    js_glue.createComputeDepthTexture = createComputeDepthTexture;
+    js_glue.getCharData = getCharData;
+    js_glue.getKerning = getKerning;
 }
 
 pub const SerializedCharDetails = js_glue.SerializedCharDetails;
@@ -91,15 +93,11 @@ pub fn connectTyping(
     disable: *const fn () void,
     update_content: *const TextCallback,
     update_selection: *const fn (u32, u32) void,
-    getCharData: *const fn (u32, u21) SerializedCharDetails,
-    getKerning: *const fn (u32, u21, u21) f32,
 ) void {
     enable_typing = enable;
     disable_typing = disable;
     update_text_content = update_content;
     update_text_selection = update_selection;
-    js_glue.getCharData = getCharData;
-    js_glue.getKerning = getKerning;
 }
 
 pub const @"meta(zigar)" = struct {
@@ -121,18 +119,14 @@ pub const @"meta(zigar)" = struct {
     }
 };
 
-var create_cache_texture: *const fn () u32 = undefined;
-var start_cache: *const fn (u32, bounding_box.BoundingBox, f32, f32) void = undefined;
-var end_cache: *const fn () void = undefined;
-
-pub fn connectCacheCallbacks(
-    create_cache_texture_cb: *const fn () u32,
-    start_cache_cb: *const fn (u32, bounding_box.BoundingBox, f32, f32) void,
-    end_cache_cb: *const fn () void,
+pub fn glueJsTextureCache(
+    createCacheTexture: *const fn () u32,
+    startCache: *const fn (u32, bounding_box.BoundingBox, f32, f32) void,
+    endCache: *const fn () void,
 ) void {
-    create_cache_texture = create_cache_texture_cb;
-    start_cache = start_cache_cb;
-    end_cache = end_cache_cb;
+    js_glue.createCacheTexture = createCacheTexture;
+    js_glue.startCache = startCache;
+    js_glue.endCache = endCache;
 }
 
 pub const ASSET_ID_MIN: u32 = 1000;
@@ -204,7 +198,7 @@ fn addImage(id_or_zero: u32, points: [4]types.PointUV, texture_id: u32) !void {
     snapshots.triggerNewSnapshot(true, true);
 }
 
-pub fn addShape(
+fn addShape(
     id_or_zero: u32,
     paths: []const []const types.Point,
     bounds: [4]types.PointUV,
@@ -302,7 +296,7 @@ fn getSelectedText() ?*texts.Text {
 fn setSelectedAsset(id: AssetId) !void {
     try commitChanges();
     state.selected_asset_id = id;
-    on_asset_select_cb(id.serialize());
+    js_glue.onAssetSelection(id.serialize());
 }
 
 pub fn updateTextContent(
@@ -426,8 +420,8 @@ pub fn onPointerDown(x: f32, y: f32) !void {
                 consts.DEFAULT_BOUNDS,
                 props,
                 effects,
-                js_glue.create_sdf_texture(),
-                if (props.blur != null) create_cache_texture() else null,
+                js_glue.createSdfTexture(),
+                if (props.blur != null) js_glue.createCacheTexture() else null,
             );
             try setSelectedAsset(AssetId{ ._prim = id });
         }
@@ -626,7 +620,7 @@ pub fn onPointerMove(x: f32, y: f32) !void {
 pub fn onPointerDoubleClick() !void {
     if (state.tool == .None and getSelectedText() != null) {
         try setTool(Tool.Text);
-        on_update_tool(@intFromEnum(Tool.Text));
+        js_glue.onUpdateTool(@intFromEnum(Tool.Text));
     }
 }
 
@@ -875,7 +869,7 @@ pub fn computeSdfs() !void {
 
                     const bounds_height = text.bounds[0].distance(text.bounds[3]);
 
-                    const compute_depth_texture_id = js_glue.create_compute_depth_texture(
+                    const compute_depth_texture_id = js_glue.createComputeDepthTexture(
                         @intFromFloat(sdf_dims.size.w),
                         @intFromFloat(sdf_dims.size.h),
                     );
@@ -933,7 +927,7 @@ pub fn updateCache() void {
                     if (!shape.outdated_cache) continue;
 
                     const cache_texture_id: u32 = if (shape.cache_texture_id) |id| id else b: {
-                        const id = create_cache_texture();
+                        const id = js_glue.createCacheTexture();
                         shape.cache_texture_id = id;
                         break :b id;
                     };
@@ -962,7 +956,7 @@ pub fn updateCache() void {
                         .max_x = size.w,
                         .max_y = size.h,
                     };
-                    start_cache(cache_texture_id, bb, size.w, size.h);
+                    js_glue.startCache(cache_texture_id, bb, size.w, size.h);
 
                     // sigma * 3 -> half of gaussian filter size, does not work in 100% cases but almost
                     const p = types.Point{
@@ -988,7 +982,7 @@ pub fn updateCache() void {
                         );
                     }
 
-                    end_cache();
+                    js_glue.endCache();
 
                     // Calculate dynamic iterations based on sigma to maintain consistent blur strength
                     const maxSigma = @max(sigma.x, sigma.y);
@@ -1406,7 +1400,7 @@ pub fn setSelectedAssetProps(props: asset_props.Props, serialized_effects: []con
 
                     shape.cache_texture_id = null;
                 } else if (props.blur != null and shape.cache_texture_id == null) {
-                    shape.cache_texture_id = create_cache_texture();
+                    shape.cache_texture_id = js_glue.createCacheTexture();
                 }
                 shape.outdated_sdf = true;
             },

--- a/src/logic/js_glue.zig
+++ b/src/logic/js_glue.zig
@@ -1,18 +1,17 @@
 const std = @import("std");
 const types = @import("types.zig");
+const bounding_box = @import("shapes/bounding_box.zig");
 
-pub var create_sdf_texture: *const fn () u32 = undefined;
-pub var create_compute_depth_texture: *const fn (u32, u32) u32 = undefined;
+pub var onAssetSelection: *const fn ([4]u32) void = undefined;
+pub var onUpdateTool: *const fn (u16) void = undefined;
+pub var createSdfTexture: *const fn () u32 = undefined;
+pub var createComputeDepthTexture: *const fn (u32, u32) u32 = undefined;
 pub var getCharData: *const fn (u32, u21) SerializedCharDetails = undefined;
 pub var getKerning: *const fn (u32, u21, u21) f32 = undefined;
 
-pub fn connectCreateSdfTexture(
-    create_sdf: *const fn () u32,
-    create_compute_depth: *const fn (u32, u32) u32,
-) void {
-    create_sdf_texture = create_sdf;
-    create_compute_depth_texture = create_compute_depth;
-}
+pub var createCacheTexture: *const fn () u32 = undefined;
+pub var startCache: *const fn (u32, bounding_box.BoundingBox, f32, f32) void = undefined;
+pub var endCache: *const fn () void = undefined;
 
 pub const SerializedCharDetails = struct {
     points: []const types.Point = &.{},

--- a/src/logic/texts/texts.zig
+++ b/src/logic/texts/texts.zig
@@ -328,7 +328,7 @@ pub const Text = struct {
 
     pub fn getSdfTextureId(self: *Text) u32 {
         return if (self.sdf_texture_id) |sdf_texture_id| sdf_texture_id else b: {
-            const sdf_tex_id = js_glue.create_sdf_texture();
+            const sdf_tex_id = js_glue.createSdfTexture();
             self.sdf_texture_id = sdf_tex_id;
             break :b sdf_tex_id;
         };

--- a/src/run.ts
+++ b/src/run.ts
@@ -44,13 +44,14 @@ export default function runCreator(
 
   const pickManager = new PickManager(device)
 
-  Logic.connectCacheCallbacks(
+  Logic.glueJsTextureCache(
     Textures.createCacheTexture,
     (texture_id: number, box: BoundingBox, width: number, height: number) => {
       startCache(device, encoder, texture_id, box, width, height)
     },
     endCache
   )
+
   Logic.connectWebGpuPrograms({
     draw_texture: (vertex_data, texture_id) => {
       drawTexture(renderPass, vertex_data.dataView, Textures.getTextureSafe(texture_id))

--- a/src/snapshots/convert.ts
+++ b/src/snapshots/convert.ts
@@ -26,7 +26,7 @@ export function toZigEffects(effects: Effect[]): ZigEffect[] {
   }))
 }
 
-// BasicProsp are shared between API & Zig
+// BasicProps are shared between API & Zig
 export function toBasicProps(props: BasicProps): BasicProps {
   return {
     blur: props.blur

--- a/src/snapshots/convert.ts
+++ b/src/snapshots/convert.ts
@@ -1,5 +1,5 @@
 import { toFill, toZigFill } from 'snapshots/fill'
-import { Effect, PointUV, ShapeProps, TypoProps, ZigEffect, ZigShapeProps } from 'types'
+import { Effect, PointUV, BasicProps, TypoProps, ZigEffect } from 'types'
 
 export function toBounds(bounds: PointUV[]): PointUV[] {
   return bounds.map((point) => ({
@@ -26,7 +26,8 @@ export function toZigEffects(effects: Effect[]): ZigEffect[] {
   }))
 }
 
-export function toShapeProps(props: ZigShapeProps): ShapeProps {
+// BasicProsp are shared between API & Zig
+export function toBasicProps(props: BasicProps): BasicProps {
   return {
     blur: props.blur
       ? {
@@ -44,17 +45,5 @@ export function toTypoProps(props: TypoProps): TypoProps {
     font_family_id: props.font_family_id,
     line_height: props.line_height,
     is_sdf_shared: props.is_sdf_shared,
-  }
-}
-
-export function toZigShapeProps(props: ShapeProps): ZigShapeProps {
-  return {
-    blur: props.blur
-      ? {
-          x: props.blur.x,
-          y: props.blur.y,
-        }
-      : null,
-    opacity: props.opacity,
   }
 }

--- a/src/snapshots/snapshots.ts
+++ b/src/snapshots/snapshots.ts
@@ -1,5 +1,5 @@
 import { Asset, ProjectSnapshot, ZigProjectSnapshot } from 'types'
-import { toBounds, toEffects, toShapeProps, toTypoProps } from './convert'
+import { toBounds, toEffects, toBasicProps, toTypoProps } from './convert'
 import * as Typing from 'typing'
 import * as Textures from 'textures'
 import * as Fonts from 'fonts'
@@ -48,7 +48,7 @@ export function saveSnapshot(snapshot: ZigProjectSnapshot) {
           }))
         ),
         bounds: toBounds([...shape.bounds]),
-        props: toShapeProps(shape.props),
+        props: toBasicProps(shape.props),
         effects: toEffects(shape.effects),
         sdf_texture_id: shape.sdf_texture_id,
         cache_texture_id: shape.cache_texture_id,
@@ -63,7 +63,7 @@ export function saveSnapshot(snapshot: ZigProjectSnapshot) {
         content: Typing.sanitizeContent(asset.text.content),
         bounds: toBounds([...asset.text.bounds]),
         typo_props: toTypoProps(asset.text.typo_props),
-        props: toShapeProps(asset.text.props),
+        props: toBasicProps(asset.text.props),
         effects: toEffects(asset.text.effects),
         sdf_texture_id: asset.text.sdf_texture_id,
       }

--- a/src/snapshots/toZigAsset.ts
+++ b/src/snapshots/toZigAsset.ts
@@ -1,5 +1,5 @@
 import { Asset, ZigAsset } from 'types'
-import { toZigEffects, toZigShapeProps } from './convert'
+import { toZigEffects } from './convert'
 import { NO_ASSET_ID } from 'consts'
 import * as Textures from 'textures'
 
@@ -11,7 +11,7 @@ export default function toZigAsset(asset: Asset): ZigAsset {
         id: asset.id || NO_ASSET_ID,
         paths: asset.paths,
         bounds: asset.bounds,
-        props: toZigShapeProps(asset.props),
+        props: asset.props,
         effects: toZigEffects(asset.effects),
         sdf_texture_id: asset.sdf_texture_id || Textures.createSDF(),
         cache_texture_id: asset.cache_texture_id || null,
@@ -24,7 +24,7 @@ export default function toZigAsset(asset: Asset): ZigAsset {
         content: asset.content,
         bounds: asset.bounds,
         typo_props: asset.typo_props,
-        props: toZigShapeProps(asset.props),
+        props: asset.props,
         effects: toZigEffects(asset.effects),
         sdf_texture_id: asset.sdf_texture_id,
       },

--- a/src/svgToShapes/collectShapesData.ts
+++ b/src/svgToShapes/collectShapesData.ts
@@ -11,11 +11,11 @@ import {
 import * as radialGradient from './radialGradient'
 import { Def, Defs, DefStop } from './definitions'
 import getProps from './getProps'
-import { Point, Fill, Effect, ShapeProps } from 'types'
+import { Point, Fill, Effect, BasicProps } from 'types'
 
 export interface ShapeData {
   paths: Point[][]
-  props: ShapeProps
+  props: BasicProps
   effects: Effect[]
   boundingBox: BoundingBox
 }
@@ -159,7 +159,7 @@ export default function collectShapesData(
     if (paths) {
       const boundingBox = getBoundingBox(paths)
 
-      const serializedProps: ShapeProps = {
+      const serializedProps: BasicProps = {
         blur: null,
         opacity: 1,
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,11 +57,13 @@ export type Effect = {
   fill: Fill
 }
 
-export type ShapeProps = {
+// Same for Zig and Api
+export type BasicProps = {
   blur: Point | null
   opacity: number
 }
 
+// same for Zig and API
 export type TypoProps = {
   font_size: number
   font_family_id: number
@@ -82,7 +84,7 @@ export type Shape = {
   id?: number // not needed while loading project but useful for undo/redo to maintain selection
   paths: Point[][]
   bounds: PointUV[]
-  props: ShapeProps
+  props: BasicProps
   effects: Effect[]
   sdf_texture_id?: number
   cache_texture_id?: number | null
@@ -92,7 +94,7 @@ export type Text = {
   id?: number // not needed while loading project but useful for undo/redo to maintain selection
   content: string
   bounds: PointUV[]
-  props: ShapeProps
+  props: BasicProps
   effects: Effect[]
   typo_props: TypoProps
   sdf_texture_id: number | null
@@ -128,11 +130,6 @@ export type ZigEffect = {
   fill: ZigFill
 }
 
-export type ZigShapeProps = {
-  blur: Point | null
-  opacity: number
-}
-
 type ZigImage = {
   id: number
   bounds: PointUV[]
@@ -143,7 +140,7 @@ type ZigShape = {
   id: number
   paths: Point[][]
   bounds: PointUV[]
-  props: ZigShapeProps
+  props: BasicProps
   effects: ZigEffect[]
   sdf_texture_id: number
   cache_texture_id: number | null
@@ -153,7 +150,7 @@ type ZigText = {
   id: number
   content: string | null
   bounds: PointUV[]
-  props: ZigShapeProps
+  props: BasicProps
   effects: ZigEffect[]
   typo_props: TypoProps
   sdf_texture_id: number | null
@@ -183,7 +180,7 @@ export type CreatorAPI = {
   setTool: (tool: CreatorTool) => void
   // we need to obtain live update!
   updateAssetTypoProps: (props: TypoProps, commit: boolean) => void // updates typography properties of selected asset
-  updateAssetProps: (props: ShapeProps, effects: Effect[], commit: boolean) => void // updates properties of selected asset
+  updateAssetProps: (props: BasicProps, effects: Effect[], commit: boolean) => void // updates properties of selected asset
   updateAssetBounds: (bounds: PointUV[], commit: boolean) => void // updates bounds of selected asset
   INFINITE_DISTANCE_THRESHOLD: number // threshold value for considering a distance as "infinite" in SDF fill effects
   INFINITE_DISTANCE: number // maximum f32 value, used for SDF fill effects

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type BasicProps = {
   opacity: number
 }
 
-// same for Zig and API
+// Same for Zig and API
 export type TypoProps = {
   font_size: number
   font_family_id: number


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated many internal callback registrations into unified wiring for more reliable asset and tool coordination
  * Streamlined texture caching and SDF texture lifecycle handling
  * Reduced global ambient type exposure for tighter encapsulation

* **API / Types**
  * Unified asset property types used across shapes and text, and simplified props flow so updates are applied directly

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->