### PR TITLE
fix: blur transformations and blur = 0

### DIFF
--- a/integration-tests/index.ts
+++ b/integration-tests/index.ts
@@ -225,7 +225,7 @@ async function test() {
     const formData = new FormData(assetPropsForm)
     try {
       const newProps = JSON.parse(formData.get('code') as string)
-      creator.updateAssetProps(newProps, [], true)
+      creator.updateAssetProps(newProps, true)
     } catch (e) {
       alert('Cannot parse JSON: ' + (e as Error).message)
     }

--- a/src/WebGPU/programs/blur/index.wgsl
+++ b/src/WebGPU/programs/blur/index.wgsl
@@ -72,19 +72,23 @@ fn main(
       if (center >= filterOffset &&
           center < 128 - filterOffset &&
           all(writeIndex < dims)) {
-
-        let denom = 2.0 * u.sigma * u.sigma;
         var acc = vec4f(0.0);
-        var wsum = 0.0;
 
-        for (var f = 0; f < u.filterDim; f++) {
-          let rel = f - filterOffset;
-          var i = center + rel;
-          let w = exp(- (f32(rel * rel)) / denom);
-          acc = acc + w * tile[r][i];
-          wsum = wsum + w;
+        if (u.filterDim <= 1 || u.sigma <= 0.0) {
+          acc = tile[r][center];
+        } else {
+          let denom = 2.0 * u.sigma * u.sigma;
+          var wsum = 0.0;
+
+          for (var f = 0; f < u.filterDim; f++) {
+            let rel = f - filterOffset;
+            let i = center + rel;
+            let w = exp(- (f32(rel * rel)) / denom);
+            acc = acc + w * tile[r][i];
+            wsum = wsum + w;
+          }
+          acc = acc / wsum;
         }
-        acc = acc / wsum;
 
         textureStore(outputTex, writeIndex, acc);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,8 +268,11 @@ export default async function initCreator(
       onUpdateTool(tool)
       Logic.setTool(tool)
     },
-    updateAssetProps: (props, effects, commit) => {
-      Logic.setSelectedAssetProps(props, toZigEffects(effects), commit)
+    updateAssetProps: (props, commit) => {
+      Logic.setSelectedAssetProps(props, commit)
+    },
+    updateAssetEffects: (effects, commit) => {
+      Logic.setSelectedAssetEffects(toZigEffects(effects), commit)
     },
     updateAssetBounds: Logic.setSelectedAssetBounds,
     updateAssetTypoProps: (typoProps, commit) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
 } from './types'
 import { destroyCanvasTextures } from 'getCanvasRenderDescriptor'
 import setCamera from 'utils/setCamera'
-import { toZigEffects } from 'snapshots/convert'
+import { toZigEffects, toZigProps } from 'snapshots/convert'
 import * as CustomPrograms from 'customPrograms'
 import * as Snapshots from 'snapshots/snapshots'
 import toZigAsset from 'snapshots/toZigAsset'
@@ -269,7 +269,7 @@ export default async function initCreator(
       Logic.setTool(tool)
     },
     updateAssetProps: (props, commit) => {
-      Logic.setSelectedAssetProps(props, commit)
+      Logic.setSelectedAssetProps(toZigProps(props), commit)
     },
     updateAssetEffects: (effects, commit) => {
       Logic.setSelectedAssetEffects(toZigEffects(effects), commit)

--- a/src/logic/index.d.ts
+++ b/src/logic/index.d.ts
@@ -163,12 +163,9 @@ declare module '*.zig' {
   ) => void
   export const generateUiElementsSdf: VoidFunction
 
-  export const setSelectedAssetProps: (
-    props: BasicProps,
-    effects: ZigEffect[],
-    commit: boolean
-  ) => void
   export const setSelectedAssetBounds: (bounds: PointUV[], commit: boolean) => void
+  export const setSelectedAssetProps: (props: BasicProps, commit: boolean) => void
+  export const setSelectedAssetEffects: (effects: ZigEffect[], commit: boolean) => void
   export const setSelectedAssetTypoProps: (typo_props: TypoProps, commit: boolean) => void
 
   export const addFont: (font_id: number) => void

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1387,7 +1387,29 @@ pub fn setSelectedAssetTypoProps(serialized: typography_props.Serialized, commit
     snapshots.triggerNewSnapshot(true, commit);
 }
 
-pub fn setSelectedAssetProps(props: asset_props.Props, serialized_effects: []const sdf_effect.Serialized, commit: bool) !void {
+pub fn setSelectedAssetEffects(serialized_effects: []const sdf_effect.Serialized, commit: bool) !void {
+    if (getSelectedAsset()) |asset| {
+        switch (asset.*) {
+            .img => {},
+            .shape => |*shape| {
+                sdf_effect.deinit(shape.effects);
+                shape.effects = try sdf_effect.deserialize(serialized_effects, std.heap.page_allocator);
+                shape.outdated_sdf = true;
+            },
+            .text => |*text| {
+                sdf_effect.deinit(text.effects);
+                text.effects = try sdf_effect.deserialize(serialized_effects, std.heap.page_allocator);
+                if (text.typo_props.is_sdf_shared) {
+                    text.is_sdf_outdated = true;
+                }
+            },
+        }
+    }
+
+    snapshots.triggerNewSnapshot(true, commit);
+}
+
+pub fn setSelectedAssetProps(props: asset_props.Props, commit: bool) !void {
     if (getSelectedAsset()) |asset| {
         switch (asset.*) {
             .img => |img| {
@@ -1396,8 +1418,6 @@ pub fn setSelectedAssetProps(props: asset_props.Props, serialized_effects: []con
             },
             .shape => |*shape| {
                 shape.props = props;
-                sdf_effect.deinit(shape.effects);
-                shape.effects = try sdf_effect.deserialize(serialized_effects, std.heap.page_allocator);
                 if (props.blur == null and shape.cache_texture_id != null) {
                     // TODO: https://github.com/mateuszJS/magic-render/issues/204
                     // destroy_texture(shape.cache_texture_id);
@@ -1406,15 +1426,14 @@ pub fn setSelectedAssetProps(props: asset_props.Props, serialized_effects: []con
                 } else if (props.blur != null and shape.cache_texture_id == null) {
                     shape.cache_texture_id = js_glue.createCacheTexture();
                 }
-                shape.outdated_sdf = true;
+                shape.outdated_cache = true;
+                // shape.outdated_sdf = true;
             },
             .text => |*text| {
                 text.props = props;
-                sdf_effect.deinit(text.effects);
-                text.effects = try sdf_effect.deserialize(serialized_effects, std.heap.page_allocator);
-                if (text.typo_props.is_sdf_shared) {
-                    text.is_sdf_outdated = true;
-                }
+                // if (text.typo_props.is_sdf_shared) {
+                //     text.is_sdf_outdated = true;
+                // }
             },
         }
     }
@@ -1490,7 +1509,7 @@ pub fn setSelectedAssetBounds(bounds: [4]types.PointUV, commit: bool) !void {
             },
             .shape => |*shape| {
                 shape.bounds = bounds;
-                shape.should_update_sdf = true;
+                // shape.should_update_sdf = true;
             },
             .text => |*text| {
                 text.bounds = bounds;

--- a/src/logic/index.zig
+++ b/src/logic/index.zig
@@ -1412,10 +1412,7 @@ pub fn setSelectedAssetEffects(serialized_effects: []const sdf_effect.Serialized
 pub fn setSelectedAssetProps(props: asset_props.Props, commit: bool) !void {
     if (getSelectedAsset()) |asset| {
         switch (asset.*) {
-            .img => |img| {
-                _ = img; // autofix
-                // img.props = props;
-            },
+            .img => {},
             .shape => |*shape| {
                 shape.props = props;
                 if (props.blur == null and shape.cache_texture_id != null) {
@@ -1426,14 +1423,10 @@ pub fn setSelectedAssetProps(props: asset_props.Props, commit: bool) !void {
                 } else if (props.blur != null and shape.cache_texture_id == null) {
                     shape.cache_texture_id = js_glue.createCacheTexture();
                 }
-                shape.outdated_cache = true;
-                // shape.outdated_sdf = true;
+                shape.outdated_cache = true; // we could also check if blur exists even
             },
             .text => |*text| {
                 text.props = props;
-                // if (text.typo_props.is_sdf_shared) {
-                //     text.is_sdf_outdated = true;
-                // }
             },
         }
     }
@@ -1509,7 +1502,7 @@ pub fn setSelectedAssetBounds(bounds: [4]types.PointUV, commit: bool) !void {
             },
             .shape => |*shape| {
                 shape.bounds = bounds;
-                // shape.should_update_sdf = true;
+                // shape.should_update_sdf = true; on 99% is not needed
             },
             .text => |*text| {
                 text.bounds = bounds;

--- a/src/logic/sdf/drawing.zig
+++ b/src/logic/sdf/drawing.zig
@@ -163,21 +163,44 @@ pub fn getBoundsWithPadding(bounds: [4]PointUV, sdf_padding: f32, scale: f32, fi
         padding.y += margin.y;
     }
 
-    var buffer: [4]PointUV = undefined;
-    const bounds_len: usize = 4;
-    for (bounds, 0..) |b, i| {
-        const b_next = bounds[(i + 1) % bounds_len];
-        const b_prev = bounds[@min((i -% 1), (bounds_len - 1)) % bounds_len];
+    const edge_x = Point{
+        .x = bounds[1].x - bounds[0].x,
+        .y = bounds[1].y - bounds[0].y,
+    };
+    const edge_y = Point{
+        .x = bounds[3].x - bounds[0].x,
+        .y = bounds[3].y - bounds[0].y,
+    };
 
-        const angle_next = b.angleTo(b_next);
-        const angle_prev = b.angleTo(b_prev);
+    const edge_x_len = edge_x.length();
+    const edge_y_len = edge_y.length();
 
-        buffer[i] = b;
-        buffer[i].x -= @cos(angle_next) * padding.x + @cos(angle_prev) * padding.x;
-        buffer[i].y -= @sin(angle_next) * padding.y + @sin(angle_prev) * padding.y;
-        buffer[i].x *= scale;
-        buffer[i].y *= scale;
-    }
+    const axis_x = Point{ .x = edge_x.x / edge_x_len, .y = edge_x.y / edge_x_len };
+    const axis_y = Point{ .x = edge_y.x / edge_y_len, .y = edge_y.y / edge_y_len };
+
+    const offset_x = Point{
+        .x = axis_x.x * padding.x,
+        .y = axis_x.y * padding.x,
+    };
+
+    const offset_y = Point{
+        .x = axis_y.x * padding.y,
+        .y = axis_y.y * padding.y,
+    };
+
+    var buffer: [4]PointUV = bounds;
+
+    buffer[0].x = (bounds[0].x - offset_x.x - offset_y.x) * scale;
+    buffer[0].y = (bounds[0].y - offset_x.y - offset_y.y) * scale;
+
+    buffer[1].x = (bounds[1].x + offset_x.x - offset_y.x) * scale;
+    buffer[1].y = (bounds[1].y + offset_x.y - offset_y.y) * scale;
+
+    buffer[2].x = (bounds[2].x + offset_x.x + offset_y.x) * scale;
+    buffer[2].y = (bounds[2].y + offset_x.y + offset_y.y) * scale;
+
+    buffer[3].x = (bounds[3].x - offset_x.x + offset_y.x) * scale;
+    buffer[3].y = (bounds[3].y - offset_x.y + offset_y.y) * scale;
 
     return buffer;
 }

--- a/src/snapshots/convert.ts
+++ b/src/snapshots/convert.ts
@@ -30,7 +30,7 @@ export function toZigProps(props: BasicProps): BasicProps {
   return {
     opacity: props.opacity,
     blur:
-      props.blur && props.blur.x > Number.EPSILON && props.blur.y > Number.EPSILON
+      props.blur && (props.blur.x > Number.EPSILON || props.blur.y > Number.EPSILON)
         ? props.blur
         : null,
   }

--- a/src/snapshots/convert.ts
+++ b/src/snapshots/convert.ts
@@ -26,6 +26,16 @@ export function toZigEffects(effects: Effect[]): ZigEffect[] {
   }))
 }
 
+export function toZigProps(props: BasicProps): BasicProps {
+  return {
+    opacity: props.opacity,
+    blur:
+      props.blur && props.blur.x > Number.EPSILON && props.blur.y > Number.EPSILON
+        ? props.blur
+        : null,
+  }
+}
+
 // BasicProps are shared between API & Zig
 export function toBasicProps(props: BasicProps): BasicProps {
   return {

--- a/src/snapshots/toZigAsset.ts
+++ b/src/snapshots/toZigAsset.ts
@@ -1,5 +1,5 @@
 import { Asset, ZigAsset } from 'types'
-import { toZigEffects } from './convert'
+import { toZigEffects, toZigProps } from './convert'
 import { NO_ASSET_ID } from 'consts'
 import * as Textures from 'textures'
 
@@ -11,7 +11,7 @@ export default function toZigAsset(asset: Asset): ZigAsset {
         id: asset.id || NO_ASSET_ID,
         paths: asset.paths,
         bounds: asset.bounds,
-        props: asset.props,
+        props: toZigProps(asset.props),
         effects: toZigEffects(asset.effects),
         sdf_texture_id: asset.sdf_texture_id || Textures.createSDF(),
         cache_texture_id: asset.cache_texture_id || null,
@@ -24,7 +24,7 @@ export default function toZigAsset(asset: Asset): ZigAsset {
         content: asset.content,
         bounds: asset.bounds,
         typo_props: asset.typo_props,
-        props: asset.props,
+        props: toZigProps(asset.props),
         effects: toZigEffects(asset.effects),
         sdf_texture_id: asset.sdf_texture_id,
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,8 @@ export type CreatorAPI = {
   setTool: (tool: CreatorTool) => void
   // we need to obtain live update!
   updateAssetTypoProps: (props: TypoProps, commit: boolean) => void // updates typography properties of selected asset
-  updateAssetProps: (props: BasicProps, effects: Effect[], commit: boolean) => void // updates properties of selected asset
+  updateAssetProps: (props: BasicProps, commit: boolean) => void // updates basic properties of selected asset
+  updateAssetEffects: (effects: Effect[], commit: boolean) => void // updates only effects of selected asset
   updateAssetBounds: (bounds: PointUV[], commit: boolean) => void // updates bounds of selected asset
   INFINITE_DISTANCE_THRESHOLD: number // threshold value for considering a distance as "infinite" in SDF fill effects
   INFINITE_DISTANCE: number // maximum f32 value, used for SDF fill effects


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized blur shader to skip weighting math for trivial blur settings
  * Improved bounds padding calculation for faster geometry handling

* **Refactor**
  * Split asset updates into separate “props” and “effects” APIs
  * Normalize tiny/insignificant blur values to be treated as absent

* **Tests**
  * Updated integration test form submission to match new props-only update call
<!-- end of auto-generated comment: release notes by coderabbit.ai -->